### PR TITLE
ci: add node versions to matrix

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -1,0 +1,34 @@
+jobs:
+    - ${{ each platform in parameters.platforms }}:
+      - ${{ each nodeVersion in parameters.nodeVersions }}:
+        - job:
+          displayName: ${{ format('{0} node v{1}', platform, nodeVersion) }}
+          timeoutInMinutes: 120
+
+          pool:
+            vmImage: $(imageName)
+          steps:
+          - task: UsePythonVersion@0
+            displayName: Setup Python
+            inputs:
+              versionSpec: '2.7'
+              architecture: 'x64'
+          - task: NodeTool@0
+            displayName: Install Node
+            inputs:
+              versionSpec: $(nodeVersion)
+          # - script: sudo apt-get update && sudo apt-get install -y gcc-4.9 g++-4.9
+          #   condition: contains(variables['Agent.JobName'], 'linux')
+          #   displayName: Install Linux build dependencies
+          - script: choco install visualcpp-build-tools --version 14.0.25420.1 -fy && npm config set msvs_version 2015
+            condition: contains(variables['Agent.JobName'], 'windows_2015')
+            displayName: Install Windows build dependencies
+          - script: choco install nasm -fy
+            displayName: Install Windows Assembler (NASM)
+            condition: contains(variables['Agent.JobName'], 'windows')
+          - script: npm ci
+            displayName: Install dependencies
+          - script: node js2bin.js --ci --node=$(nodeVersion)  --size=2MB --size=4MB --upload --clean
+            displayName: Build base node binaries
+            env:
+              GITHUB_TOKEN: $(PersonalGithubToken)

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -1,34 +1,34 @@
 jobs:
-    - ${{ each platform in parameters.platforms }}:
-      - ${{ each nodeVersion in parameters.nodeVersions }}:
-        - job:
-          displayName: ${{ format('{0} node v{1}', platform, nodeVersion) }}
-          timeoutInMinutes: 120
+  - ${{ each platform in parameters.platforms }}:
+    - ${{ each nodeVersion in parameters.nodeVersions }}:
+      - job:
+        displayName: ${{ format('{0} node v{1}', platform, nodeVersion) }}
+        timeoutInMinutes: 120
 
-          pool:
-            vmImage: $(imageName)
-          steps:
-          - task: UsePythonVersion@0
-            displayName: Setup Python
-            inputs:
-              versionSpec: '2.7'
-              architecture: 'x64'
-          - task: NodeTool@0
-            displayName: Install Node
-            inputs:
-              versionSpec: $(nodeVersion)
-          # - script: sudo apt-get update && sudo apt-get install -y gcc-4.9 g++-4.9
-          #   condition: contains(variables['Agent.JobName'], 'linux')
-          #   displayName: Install Linux build dependencies
-          - script: choco install visualcpp-build-tools --version 14.0.25420.1 -fy && npm config set msvs_version 2015
-            condition: contains(variables['Agent.JobName'], 'windows_2015')
-            displayName: Install Windows build dependencies
-          - script: choco install nasm -fy
-            displayName: Install Windows Assembler (NASM)
-            condition: contains(variables['Agent.JobName'], 'windows')
-          - script: npm ci
-            displayName: Install dependencies
-          - script: node js2bin.js --ci --node=$(nodeVersion)  --size=2MB --size=4MB --upload --clean
-            displayName: Build base node binaries
-            env:
-              GITHUB_TOKEN: $(PersonalGithubToken)
+        pool:
+          vmImage: $(imageName)
+        steps:
+        - task: UsePythonVersion@0
+          displayName: Setup Python
+          inputs:
+            versionSpec: '2.7'
+            architecture: 'x64'
+        - task: NodeTool@0
+          displayName: Install Node
+          inputs:
+            versionSpec: $(nodeVersion)
+        # - script: sudo apt-get update && sudo apt-get install -y gcc-4.9 g++-4.9
+        #   condition: contains(variables['Agent.JobName'], 'linux')
+        #   displayName: Install Linux build dependencies
+        - script: choco install visualcpp-build-tools --version 14.0.25420.1 -fy && npm config set msvs_version 2015
+          condition: contains(variables['Agent.JobName'], 'windows_2015')
+          displayName: Install Windows build dependencies
+        - script: choco install nasm -fy
+          displayName: Install Windows Assembler (NASM)
+          condition: contains(variables['Agent.JobName'], 'windows')
+        - script: npm ci
+          displayName: Install dependencies
+        - script: node js2bin.js --ci --node=$(nodeVersion)  --size=2MB --size=4MB --upload --clean
+          displayName: Build base node binaries
+          env:
+            GITHUB_TOKEN: $(PersonalGithubToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,48 +1,34 @@
 jobs:
-- job: BuildBaseExe
-  timeoutInMinutes: 120
-  strategy:
-    matrix:
-      node_12_x:
-        nodeVersion: 12.x
-      node_13_x:
-        nodeVersion: 13.x
-      node_14_x:
-        nodeVersion: 14.x
-      linux:
-        imageName: 'ubuntu-16.04'
-      mac:
-        imageName: 'macos-10.14'
-      windows_2017:
-        imageName: 'vs2017-win2016'
-      # windows_2015:
-      #   imageName: 'vs2017-win2016'
-#      alpine:
-#        imageName: 'ubuntu-16.04'
-  pool:
-    vmImage: $(imageName)
-  steps:
-  - task: UsePythonVersion@0
-    displayName: Setup Python
-    inputs:
-      versionSpec: '2.7'
-      architecture: 'x64'
-  - task: NodeTool@0
-    displayName: Install Node
-    inputs:
-      versionSpec: $(nodeVersion)
-  # - script: sudo apt-get update && sudo apt-get install -y gcc-4.9 g++-4.9
-  #   condition: contains(variables['Agent.JobName'], 'linux')
-  #   displayName: Install Linux build dependencies
-  - script: choco install visualcpp-build-tools --version 14.0.25420.1 -fy && npm config set msvs_version 2015
-    condition: contains(variables['Agent.JobName'], 'windows_2015')
-    displayName: Install Windows build dependencies
-  - script: choco install nasm -fy
-    displayName: Install Windows Assembler (NASM)
-    condition: contains(variables['Agent.JobName'], 'windows')
-  - script: npm ci
-    displayName: Install dependencies
-  - script: node js2bin.js --ci --node=$(nodeVersion)  --size=2MB --size=4MB --upload --clean
-    displayName: Build base node binaries
-    env:
-      GITHUB_TOKEN: $(PersonalGithubToken)
+  - ${{ each platform in parameters.platform }}:
+    - ${{ each nodeVersion in parameters.nodeVersion }}:
+        - job: 
+          displayName: ${{ platform }} node v${{ nodeVersion }}
+          timeoutInMinutes: 120
+
+          pool:
+            vmImage: $(imageName)
+          steps:
+          - task: UsePythonVersion@0
+            displayName: Setup Python
+            inputs:
+              versionSpec: '2.7'
+              architecture: 'x64'
+          - task: NodeTool@0
+            displayName: Install Node
+            inputs:
+              versionSpec: $(nodeVersion)
+          # - script: sudo apt-get update && sudo apt-get install -y gcc-4.9 g++-4.9
+          #   condition: contains(variables['Agent.JobName'], 'linux')
+          #   displayName: Install Linux build dependencies
+          - script: choco install visualcpp-build-tools --version 14.0.25420.1 -fy && npm config set msvs_version 2015
+            condition: contains(variables['Agent.JobName'], 'windows_2015')
+            displayName: Install Windows build dependencies
+          - script: choco install nasm -fy
+            displayName: Install Windows Assembler (NASM)
+            condition: contains(variables['Agent.JobName'], 'windows')
+          - script: npm ci
+            displayName: Install dependencies
+          - script: node js2bin.js --ci --node=$(nodeVersion)  --size=2MB --size=4MB --upload --clean
+            displayName: Build base node binaries
+            env:
+              GITHUB_TOKEN: $(PersonalGithubToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,7 @@
+parameters:
+    platform: ['ubuntu-16.04','macos-10.14', 'vs2017-win2016']
+    nodeVersion: ['12.x','13.x', '14.x']
+
 jobs:
   - ${{ each platform in parameters.platform }}:
     - ${{ each nodeVersion in parameters.nodeVersion }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 jobs:
-  - template: azure-pipelines-template.yml
+- template: azure-pipelines-template.yml
   parameters: 
     nodeVersions: 
       - 12.x

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,12 @@ jobs:
   timeoutInMinutes: 120
   strategy:
     matrix:
+      node_12_x:
+        nodeVersion: 12.x
+      node_13_x:
+        nodeVersion: 13.x
+      node_14_x:
+        nodeVersion: 14.x
       linux:
         imageName: 'ubuntu-16.04'
       mac:
@@ -24,7 +30,7 @@ jobs:
   - task: NodeTool@0
     displayName: Install Node
     inputs:
-      versionSpec: '10.x'
+      versionSpec: $(nodeVersion)
   # - script: sudo apt-get update && sudo apt-get install -y gcc-4.9 g++-4.9
   #   condition: contains(variables['Agent.JobName'], 'linux')
   #   displayName: Install Linux build dependencies
@@ -36,9 +42,7 @@ jobs:
     condition: contains(variables['Agent.JobName'], 'windows')
   - script: npm ci
     displayName: Install dependencies
-  - script: node js2bin.js --ci --node=12.18.4  --size=2MB --size=4MB --upload --clean
+  - script: node js2bin.js --ci --node=$(nodeVersion)  --size=2MB --size=4MB --upload --clean
     displayName: Build base node binaries
     env:
       GITHUB_TOKEN: $(PersonalGithubToken)
-
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,12 @@
-parameters:
-    platform: ['ubuntu-16.04','macos-10.14', 'vs2017-win2016']
-    nodeVersion: ['12.x','13.x', '14.x']
+parameters: 
+    nodeVersion: 
+      - 12.x
+      - 13.x
+      - 14.x
+    platform: 
+      - ubuntu-16.04
+      - macos-10.14
+      - vs2017-win2016
 
 jobs:
   - ${{ each platform in parameters.platform }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,44 +1,11 @@
-parameters: 
-    nodeVersion: 
+jobs:
+  - template: azure-pipelines-template.yml
+  parameters: 
+    nodeVersions: 
       - 12.x
       - 13.x
       - 14.x
-    platform: 
+    platforms: 
       - ubuntu-16.04
       - macos-10.14
       - vs2017-win2016
-
-jobs:
-  - ${{ each platform in parameters.platform }}:
-    - ${{ each nodeVersion in parameters.nodeVersion }}:
-        - job: 
-          displayName: ${{ platform }} node v${{ nodeVersion }}
-          timeoutInMinutes: 120
-
-          pool:
-            vmImage: $(imageName)
-          steps:
-          - task: UsePythonVersion@0
-            displayName: Setup Python
-            inputs:
-              versionSpec: '2.7'
-              architecture: 'x64'
-          - task: NodeTool@0
-            displayName: Install Node
-            inputs:
-              versionSpec: $(nodeVersion)
-          # - script: sudo apt-get update && sudo apt-get install -y gcc-4.9 g++-4.9
-          #   condition: contains(variables['Agent.JobName'], 'linux')
-          #   displayName: Install Linux build dependencies
-          - script: choco install visualcpp-build-tools --version 14.0.25420.1 -fy && npm config set msvs_version 2015
-            condition: contains(variables['Agent.JobName'], 'windows_2015')
-            displayName: Install Windows build dependencies
-          - script: choco install nasm -fy
-            displayName: Install Windows Assembler (NASM)
-            condition: contains(variables['Agent.JobName'], 'windows')
-          - script: npm ci
-            displayName: Install dependencies
-          - script: node js2bin.js --ci --node=$(nodeVersion)  --size=2MB --size=4MB --upload --clean
-            displayName: Build base node binaries
-            env:
-              GITHUB_TOKEN: $(PersonalGithubToken)


### PR DESCRIPTION
This uses [parameterized jobs](https://github.com/nedrebo/parameterized-azure-jobs) to allow a better matrix which not only has platforms but also node versions.

This now supports the following matrix.
```
macos-10.14 node v12.x
macos-10.14 node v13.x
macos-10.14 node v14.x
ubuntu-16.04 node v12.x
ubuntu-16.04 node v13.x
ubuntu-16.04 node v14.x
vs2017-win2016 node v12.x
vs2017-win2016 node v13.x
vs2017-win2016 node v14.x
```

Feel free to make additional commits if need be.