### PR TITLE
fix: use the name --size value when building

### DIFF
--- a/js2bin.js
+++ b/js2bin.js
@@ -98,7 +98,7 @@ if (args.build) {
         const arch = args.arch || 'x64';
         log(`building for version=${version}, plat=${plat} app=${app}} arch=${arch}`);
         const outName = args.name ? `${args.name}-${plat}-${arch}` : undefined;
-        return builder.buildFromCached(plat, arch, outName, args.cache);
+        return builder.buildFromCached(plat, arch, outName, args.cache, args.size);
       });
     });
   });

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -44,6 +44,7 @@ function buildName(platform, arch, placeHolderSizeMB, version) {
 
 class NodeJsBuilder {
   constructor(cwd, version, mainAppFile, appName) {
+
     this.version = version;
     this.appFile = resolve(mainAppFile);
     this.appName = appName;
@@ -262,12 +263,13 @@ class NodeJsBuilder {
       .catch(err => this.printDiskUsage().then(() => { throw err; }));
   }
 
-  buildFromCached(platform = 'linux', arch = 'x64', outFile = undefined, cache = false) {
+  buildFromCached(platform = 'linux', arch = 'x64', outFile = undefined, cache = false, size = '2MB') {
     const mainAppFileCont = this.getAppContentToBundle();
     this.placeHolderSizeMB = Math.ceil(mainAppFileCont.length / 1024 / 1024); // 2, 4, 6, 8...
     if (this.placeHolderSizeMB % 2 !== 0) {
       this.placeHolderSizeMB += 1;
     }
+    if (size) this.placeHolderSizeMB = parseInt( size.toUpperCase().replaceAll('MB', '') )
 
     return this.downloadCachedBuild(platform, arch)
       .then(cachedFile => {


### PR DESCRIPTION
`buildFromCached` was overriding --size value and not using cached build