### PR TITLE
Adding support for _third_party_main.js

### DIFF
--- a/src/patch/16.16.0/node.cc.patch
+++ b/src/patch/16.16.0/node.cc.patch
@@ -1,0 +1,16 @@
+--- src/node.cc	2022-08-26 13:05:24.458396341 -0500
++++ src/node.cc	2022-08-26 13:06:12.179824998 -0500
+@@ -479,6 +479,13 @@
+     return scope.EscapeMaybe(cb(info));
+   }
+ 
++  // To allow people to extend Node in different ways, this hook allows
++  // one to drop a file lib/_third_party_main.js into the build
++  // directory which will be executed instead of Node's normal loading.
++  if (NativeModuleEnv::Exists("_third_party_main")) {
++    return StartExecution(env, "internal/main/run_third_party_main");
++  }
++
+   if (env->worker_context() != nullptr) {
+     return StartExecution(env, "internal/main/worker_thread");
+   }

--- a/src/patch/16.16.0/run_third_party_main.js.patch
+++ b/src/patch/16.16.0/run_third_party_main.js.patch
@@ -1,0 +1,16 @@
+--- /dev/null	2022-08-18 11:11:24.665352687 -0500
++++ lib/internal/main/run_third_party_main.js	2022-08-26 13:55:53.482283827 -0500
+@@ -0,0 +1,13 @@
++'use strict';
++
++const {
++  prepareMainThreadExecution
++} = require('internal/bootstrap/pre_execution');
++
++prepareMainThreadExecution();
++markBootstrapComplete();
++
++// Legacy _third_party_main.js support
++process.nextTick(() => {
++  require('_third_party_main');
++});


### PR DESCRIPTION
support was removed in v15 and beyond. Resolves https://github.com/criblio/js2bin/issues/21

The approach here is to patch the node source code to add back the support that was removed in this PR https://github.com/nodejs/node/pull/33971 for this issue https://github.com/nodejs/node/issues/24017

There's just two simple patches that need applying to re-enable support