### PR TITLE
Disable usage of <sys/random.h> in older version of glibc

### DIFF
--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -10,6 +10,7 @@ const pkg = require('../package.json');
 
 const isWindows = process.platform === 'win32';
 const isDarwin = process.platform === 'darwin';
+const isLinux = process.platform === 'linux';
 
 const prettyPlatform = {
   win32: 'windows',
@@ -214,10 +215,14 @@ class NodeJsBuilder {
     await patchFile(
       this.nodePath('src', 'node_credentials.cc'),
       join(this.patchDir, 'node_credentials.cc.patch'));
-  
+
     await patchFile(
       this.nodePath('deps','v8','src','heap','base','asm','arm64','push_registers_asm.cc'),
-      join(this.patchDir, 'push_registers_asm.cc.patch'));	  
+      join(this.patchDir, 'push_registers_asm.cc.patch'));
+
+    isLinux && await patchFile(
+      this.nodePath('deps','cares','config','linux','ares_config.h'),
+      join(this.patchDir, 'no_rand_on_glibc.patch'));
   }
 
   async applyPatches() {

--- a/src/patch/18.20.2/no_rand_on_glibc.patch
+++ b/src/patch/18.20.2/no_rand_on_glibc.patch
@@ -1,0 +1,24 @@
+disable usage of <sys/random.h>
+
+--- /dev/null
++++ deps/cares/config/linux/ares_config.h
+@@ -116,7 +116,9 @@
+ #define HAVE_GETNAMEINFO 1
+
+ /* Define to 1 if you have `getrandom` */
++#if defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 25
+ #define HAVE_GETRANDOM 1
++#endif
+
+ /* Define to 1 if you have `getservbyport_r` */
+ #define HAVE_GETSERVBYPORT_R 1
+@@ -329,7 +331,9 @@
+ #define HAVE_SYS_PARAM_H 1
+
+ /* Define to 1 if you have the <sys/random.h> header file. */
++#if defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 25
+ #define HAVE_SYS_RANDOM_H 1
++#endif
+
+ /* Define to 1 if you have the <sys/select.h> header file. */
+ #define HAVE_SYS_SELECT_H 1


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/52223

The CI status of previous PR: https://github.com/criblio/js2bin/pull/53  was misleading
![image](https://github.com/criblio/js2bin/assets/39981869/ffd2f003-1edd-4e91-8997-c541bf8dde87)
