### PR TITLE
upgraded node version to 18.20.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 build/
+cache/

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,8 +1,20 @@
 FROM centos:7
 
+# use Centos vault for downloading
+RUN sed -i 's/mirror.centos.org/vault.centos.org/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
+
+RUN yum install -y centos-release-scl
+
+# installing centos-release-scl adds the Software Collections repo to Yum's configuration,
+# so the following replacement should be used for downloading from Centos vault
+RUN sed -i 's/mirror.centos.org/vault.centos.org/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
+   
 # use node 10 as it's guaranteed to run on CentOS6
-RUN yum install -y centos-release-scl && \
-    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum install -y devtoolset-8 python36 wget patch && \
     wget -q https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-x64.tar.gz && \
     tar -xf node-v10.23.0-linux-x64.tar.gz && \ 

--- a/Dockerfile.centos7.arm64
+++ b/Dockerfile.centos7.arm64
@@ -1,8 +1,20 @@
 FROM centos:7
 
+# use Centos vault for downloading
+RUN sed -i 's/mirror.centos.org/vault.centos.org/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
+
+RUN yum install -y centos-release-scl
+
+# installing centos-release-scl adds the Software Collections repo to Yum's configuration,
+# so the following replacement should be used for downloading from Centos vault
+RUN sed -i 's|mirror.centos.org/centos|vault.centos.org/altarch|g' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
+
 # use node 10 as it's guaranteed to run on CentOS6
-RUN yum install -y centos-release-scl && \
-    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum install -y devtoolset-8 python36 wget patch && \
     wget -q https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-arm64.tar.gz && \
     gunzip node-v10.23.0-linux-arm64.tar.gz && tar xf node-v10.23.0-linux-arm64.tar && rm node-v10.23.0-linux-arm64.tar && \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,27 +6,27 @@ jobs:
       linux_arm64:
         imageName: 'ubuntu-20.04'
         arch: 'linux/arm64'
-        node: '18.20.2'
+        node: '18.20.4'
 
       linux_amd64:
         imageName: 'ubuntu-20.04'
         arch: 'linux/amd64'
-        node: '18.20.2'
+        node: '18.20.4'
         ptrcompress: false
 
       linux_amd64_ptrc:
         imageName: 'ubuntu-20.04'
         arch: 'linux/amd64'
-        node: '18.20.2'
+        node: '18.20.4'
         ptrcompress: true
 
       windows_2019:
         imageName: 'windows-2019'
-        node: '18.20.2'
+        node: '18.20.4'
         ptrcompress: false
       windows_2019_ptrc:
         imageName: 'windows-2019'
-        node: '18.20.2'
+        node: '18.20.4'
         ptrcompress: true
 
       # mac:

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -199,6 +199,7 @@ class NodeJsBuilder {
       this.nodePath('src', 'node.cc'),
       join(this.patchDir, 'node.cc.patch'));
   }
+
   async patchNodeCompileIssues() {
     await patchFile(
       this.nodePath('node.gyp'),
@@ -208,26 +209,14 @@ class NodeJsBuilder {
       this.nodePath('vcbuild.bat'),
       join(this.patchDir, 'vcbuild.bat.patch'));
 
-    await patchFile(
-      this.nodePath('src', 'node_main.cc'),
-      join(this.patchDir, 'node_main.cc.patch'));
-
-    await patchFile(
-      this.nodePath('src', 'node_credentials.cc'),
-      join(this.patchDir, 'node_credentials.cc.patch'));
-
-    await patchFile(
-      this.nodePath('deps','v8','src','heap','base','asm','arm64','push_registers_asm.cc'),
-      join(this.patchDir, 'push_registers_asm.cc.patch'));
-
     isLinux && await patchFile(
       this.nodePath('deps','cares','config','linux','ares_config.h'),
       join(this.patchDir, 'no_rand_on_glibc.patch'));
   }
 
   async applyPatches() {
-     await this.patchThirdPartyMain();
-     await this.patchNodeCompileIssues();
+    await this.patchThirdPartyMain();
+    await this.patchNodeCompileIssues();
   }
 
   printDiskUsage() {

--- a/src/patch/18.20.4/no_rand_on_glibc.patch
+++ b/src/patch/18.20.4/no_rand_on_glibc.patch
@@ -1,0 +1,24 @@
+disable usage of <sys/random.h>
+
+--- deps/cares/config/linux/ares_config.h
++++ deps/cares/config/linux/ares_config.h
+@@ -116,7 +116,9 @@
+ #define HAVE_GETNAMEINFO 1
+
+ /* Define to 1 if you have `getrandom` */
++#if defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 25
+ #define HAVE_GETRANDOM 1
++#endif
+
+ /* Define to 1 if you have `getservbyport_r` */
+ #define HAVE_GETSERVBYPORT_R 1
+@@ -329,7 +331,9 @@
+ #define HAVE_SYS_PARAM_H 1
+
+ /* Define to 1 if you have the <sys/random.h> header file. */
++#if defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 25
+ #define HAVE_SYS_RANDOM_H 1
++#endif
+
+ /* Define to 1 if you have the <sys/select.h> header file. */
+ #define HAVE_SYS_SELECT_H 1

--- a/src/patch/18.20.4/node.cc.patch
+++ b/src/patch/18.20.4/node.cc.patch
@@ -1,0 +1,17 @@
+--- src/node.cc
++++ src/node.cc
+@@ -304,6 +304,14 @@ MaybeLocal<Value> StartExecution(Environment* env, StartExecutionCallback cb) {
+     return env->RunSnapshotDeserializeMain();
+   }
+ 
++  // To allow people to extend Node in different ways, this hook allows
++  // one to drop a file lib/_third_party_main.js into the build
++  // directory which will be executed instead of Node's normal loading.
++  if (env->builtin_loader()->Exists("_third_party_main")) {
++    return StartExecution(env, "internal/main/run_third_party_main");
++  }
++
++
+   if (env->worker_context() != nullptr) {
+     return StartExecution(env, "internal/main/worker_thread");
+   }

--- a/src/patch/18.20.4/node.gyp.patch
+++ b/src/patch/18.20.4/node.gyp.patch
@@ -1,0 +1,13 @@
+disable building of cctest as it (a) it fails to build due to align_alloc and (b) it is just a waste of time
+
+--- node.gyp
++++ node.gyp
+@@ -1217,7 +1217,7 @@
+     }, # fuzz_env
+     {
+       'target_name': 'cctest',
+-      'type': 'executable',
++      'type': 'none',
+ 
+       'dependencies': [
+         '<(node_lib_target_name)',

--- a/src/patch/18.20.4/run_third_party_main.js.patch
+++ b/src/patch/18.20.4/run_third_party_main.js.patch
@@ -1,0 +1,17 @@
+--- /dev/null
++++ lib/internal/main/run_third_party_main.js
+@@ -0,0 +1,14 @@
++'use strict';
++
++const {
++  prepareMainThreadExecution,
++  markBootstrapComplete
++} = require('internal/process/pre_execution');
++
++prepareMainThreadExecution();
++markBootstrapComplete();
++
++// Legacy _third_party_main.js support
++process.nextTick(() => {
++  require('_third_party_main');
++});

--- a/src/patch/18.20.4/vcbuild.bat.patch
+++ b/src/patch/18.20.4/vcbuild.bat.patch
@@ -1,0 +1,28 @@
+expose option for configuring pointer compression
+
+--- vcbuild.bat
++++ vcbuild.bat
+@@ -74,6 +74,7 @@ set no_shared_roheap=
+ set doc=
+ set extra_msbuild_args=
+ set exit_code=0
++set v8_ptr_compress=
+ 
+ :next-arg
+ if "%1"=="" goto args-done
+@@ -152,6 +153,7 @@ if /i "%1"=="cctest"        set cctest=1&goto arg-ok
+ if /i "%1"=="openssl-no-asm"   set openssl_no_asm=1&goto arg-ok
+ if /i "%1"=="no-shared-roheap" set no_shared_roheap=1&goto arg-ok
+ if /i "%1"=="doc"           set doc=1&goto arg-ok
++if /i "%1"=="v8_ptr_compress"   set v8_ptr_compress=1&goto arg-ok
+ if /i "%1"=="binlog"        set extra_msbuild_args=/binaryLogger:%config%\node.binlog&goto arg-ok
+ 
+ echo Error: invalid command line option `%1`.
+@@ -210,6 +212,7 @@ if defined debug_nghttp2    set configure_flags=%configure_flags% --debug-nghttp
+ if defined openssl_no_asm   set configure_flags=%configure_flags% --openssl-no-asm
+ if defined no_shared_roheap set configure_flags=%configure_flags% --disable-shared-readonly-heap
+ if defined DEBUG_HELPER     set configure_flags=%configure_flags% --verbose
++if defined v8_ptr_compress  set configure_flags=%configure_flags% --experimental-enable-pointer-compression
+ if "%target_arch%"=="x86" if "%PROCESSOR_ARCHITECTURE%"=="AMD64" set configure_flags=%configure_flags% --no-cross-compiling
+ 
+ if not exist "%~dp0deps\icu" goto no-depsicu


### PR DESCRIPTION
- Added patches for node 18.20.4
- Updated `azure-pipelines.yml`
- Cleaned up `NodeBuilder` from reading obsolete patch files
- Updated `Dockerfile.centos7` and `Dockerfile.centos7.arm64` to use Centos vault to be able to build the `cribl/js2bin-builder` docker images