### PR TITLE
Patch for libuv watcher leak

### DIFF
--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -198,6 +198,9 @@ class NodeJsBuilder {
     await patchFile(
       this.nodePath('src', 'node.cc'),
       join(this.patchDir, 'node.cc.patch'));
+    await patchFile(
+      this.nodePath('deps', 'uv', 'src', 'win', 'fs-event.c'),
+      join(this.patchDir, 'fs-event.c.patch'));
   }
 
   async patchNodeCompileIssues() {

--- a/src/patch/18.20.4/fs-event.c.patch
+++ b/src/patch/18.20.4/fs-event.c.patch
@@ -1,0 +1,11 @@
+--- a/deps/uv/src/win/fs-event.c
++++ b/deps/uv/src/win/fs-event.c
+@@ -266,6 +266,8 @@ short_path_done:
+     }
+ 
+     dir_to_watch = dir;
++    uv__free(short_path);
++    short_path = NULL;
+     uv__free(pathw);
+     pathw = NULL;
+   }


### PR DESCRIPTION
Creates a patch for the watch leak we are seeing in nodejs.  The leak is windows only and takes place in the the fs-event.c file.  The main issues is that libuv is allocating space for a short_path for each file a watch is being applied to that is never freed up after the watch is successfully applied, causing a native memory leak in node.

Fix for CRIBL-28089 and https://github.com/nodejs/node/issues/52769

Tested the patch locally on my dev box with a `js2bin ci` and manually verified its being inserted at the correct placement for 18.20.4.  The leak fix itself has been tested directly through a C++ console app linking libuv as well as being built into Node.  Without the fix we see the memory continue to grow and with the fix we are seeing it remain stable.  