### PR TITLE
Add support for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+{ 
+	"name": "Linux js2bin development container",
+	"image": "node:20.18.0-bullseye-slim",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-from-docker:latest": {},
+		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+		"packages": [
+			"curl",
+			"g++",
+			"git",
+			"make",
+			"nano",
+			"patch",
+			"python3",
+			"procps",
+			"wget"
+		]}
+	},
+	"runArgs": [
+		"--network=host"
+	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools",
+				"ms-vscode.cpptools-extension-pack",
+				"dbaeumer.vscode-eslint",
+				"eamodio.gitlens",
+				"esbenp.prettier-vscode",
+				"bierner.markdown-mermaid",
+				"spadin.memento-inputs",
+				"streetsidesoftware.code-spell-checker",
+				"timonwong.shellcheck"
+			]
+		}
+	},
+
+	"containerEnv": {
+		"LANG": "C.UTF-8",
+		"LC_ALL": "C.UTF-8"
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	"postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh",
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+	"workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
+	"workspaceFolder": "${localWorkspaceFolder}"
+}

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -ex
+
+NVM_VERSION="v0.40.1"
+
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash


### PR DESCRIPTION
By adding DevContainer support, we can utilize a Linux-based build environment, which allows us to operate independently of Xcode and avoids the use of Darwin/macOS-specific flags. This would better reflect the build performed in CI

With current build on Mac:
```
node js2bin.js --ci --container=true --pointer-compress=false --node=20.18.0 --size=6MB --size=4MB --arch=linux/arm64 --platform=linux
2024-12-23T12:58:36.557Z - running: make -j12 ...
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C out BUILDTYPE=Release V=0
```
