### PR TITLE
add MacOS builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,14 @@ jobs:
 
   pool:
     vmImage: $(imageName)
+
+  variables:
+    # Do not attempt to upload to the Github Release when building a PR
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      ci_args: ''
+    ${{ else }}:
+      ci_args: '--upload'
+
   steps:
   - task: UsePythonVersion@0
     displayName: Setup Python
@@ -80,15 +88,20 @@ jobs:
     displayName: setup docker for multi platform
     condition: contains(variables['Agent.JobName'], 'linux')
   ## linux and macos builds
-  - script: node js2bin.js --ci --container=true --pointer-compress=$(ptrcompress) --node=$(node) --size=6MB --size=4MB --upload --clean --arch=${ARCH}
+  - script: node js2bin.js --ci --container=true --pointer-compress=$(ptrcompress) --node=$(node) --size=6MB --size=4MB --clean --arch=$(arch) --cache $(ci_args)
     displayName: Build base node binaries linux or macos
     condition: or(contains(variables['Agent.JobName'], 'linux'), contains(variables['Agent.JobName'], 'macos'))
     env:
       GITHUB_TOKEN: $(PersonalGithubToken)
-      ARCH: $(arch)
-  ## non-linux builds
-  - script: node js2bin.js --ci --container=true --pointer-compress=$(ptrcompress) --node=$(node) --size=6MB --size=4MB --upload --clean
+  ## other builds
+  - script: node js2bin.js --ci --container=true --pointer-compress=$(ptrcompress) --node=$(node) --size=6MB --size=4MB --clean --cache $(ci_args)
     displayName: Build base node binaries non-linux
     condition: not(or(contains(variables['Agent.JobName'], 'linux'), contains(variables['Agent.JobName'], 'macos')))
     env:
       GITHUB_TOKEN: $(PersonalGithubToken)
+  # keep the built binaries
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: cache
+      artifact: $(System.JobName)
+      publishLocation: pipeline

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
       macos_15:
         imageName: 'macOS-15'
         node: '20.18.0'
+        arch: 'arm64'
         ptrcompress: false
 
   pool:
@@ -75,6 +76,6 @@ jobs:
       GITHUB_TOKEN: $(PersonalGithubToken)
   - task: PublishPipelineArtifact@1
     inputs:
-      targetPath: 'out/Release/node'
+      targetPath: 'build/node-v20.18.0/out/Release/node'
       artifact: 'node'
       publishLocation: pipeline

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,38 +3,54 @@ jobs:
   timeoutInMinutes: 0
   strategy:
     matrix:
-      #linux_arm64:
-      #  imageName: 'ubuntu-20.04'
-      #  arch: 'linux/arm64'
-      #  node: '20.18.0'
+      # linux_arm64:
+      #   imageName: 'ubuntu-20.04'
+      #   arch: 'linux/arm64'
+      #   node: '20.18.0'
 
-      #linux_amd64:
-      #  imageName: 'ubuntu-20.04'
-      #  arch: 'linux/amd64'
-      #  node: '20.18.0'
-      #  ptrcompress: false
+      # linux_amd64:
+      #   imageName: 'ubuntu-20.04'
+      #   arch: 'linux/amd64'
+      #   node: '20.18.0'
+      #   ptrcompress: false
 
-      #linux_amd64_ptrc:
-      #  imageName: 'ubuntu-20.04'
-      #  arch: 'linux/amd64'
-      #  node: '20.18.0'
-      #  ptrcompress: true
+      # linux_amd64_ptrc:
+      #   imageName: 'ubuntu-20.04'
+      #   arch: 'linux/amd64'
+      #   node: '20.18.0'
+      #   ptrcompress: true
 
-      #windows_2019:
-      #  imageName: 'windows-2019'
-      #  node: '20.18.0'
-      #  ptrcompress: false
-      #windows_2019_ptrc:
-      #  imageName: 'windows-2019'
-      #  node: '20.18.0'
-      #  ptrcompress: true
+      # windows_2019:
+      #   imageName: 'windows-2019'
+      #   node: '20.18.0'
+      #   ptrcompress: false
+      # windows_2019_ptrc:
+      #   imageName: 'windows-2019'
+      #   node: '20.18.0'
+      #   ptrcompress: true
 
-      macos_15:
+      macos_arm64:
         imageName: 'macOS-15'
         node: '20.18.0'
         arch: 'arm64'
         ptrcompress: false
+      # macos_arm64_ptrc:
+      #   imageName: 'macOS-15'
+      #   node: '20.18.0'
+      #   arch: 'arm64'
+      #   ptrcompress: true
 
+      # macos_x64:
+      #   imageName: 'macOS-15'
+      #   node: '20.18.0'
+      #   arch: 'x64'
+      #   ptrcompress: false
+      # macos_x64_ptrc:
+      #   imageName: 'macOS-15'
+      #   node: '20.18.0'
+      #   arch: 'x64'
+      #   ptrcompress: true
+      
   pool:
     vmImage: $(imageName)
   steps:
@@ -61,17 +77,19 @@ jobs:
   - script: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
     displayName: setup docker for multi platform
     condition: contains(variables['Agent.JobName'], 'linux')
-  ## linux builds
-  - script: node js2bin.js --ci --container=true --pointer-compress=$(ptrcompress) --node=$(node) --size=6MB --size=4MB --upload --clean --arch=${ARCH}
-    displayName: Build base node binaries linux
-    condition: contains(variables['Agent.JobName'], 'linux')
+  ## linux and macos builds
+  # TODO replace this line
+  # - script: node js2bin.js --ci --container=true --pointer-compress=$(ptrcompress) --node=$(node) --size=6MB --size=4MB --upload --clean --arch=${ARCH}
+  - script: node js2bin.js --ci --container=true --pointer-compress=$(ptrcompress) --node=$(node) --size=6MB --clean --arch=${ARCH}
+    displayName: Build base node binaries linux or macos
+    condition: or(contains(variables['Agent.JobName'], 'linux'), contains(variables['Agent.JobName'], 'macos'))
     env:
       GITHUB_TOKEN: $(PersonalGithubToken)
       ARCH: $(arch)
   ## non-linux builds
   - script: node js2bin.js --ci --container=true --pointer-compress=$(ptrcompress) --node=$(node) --size=6MB --size=4MB --upload --clean
     displayName: Build base node binaries non-linux
-    condition: not(contains(variables['Agent.JobName'], 'linux'))
+    condition: not(or(contains(variables['Agent.JobName'], 'linux'), contains(variables['Agent.JobName'], 'macos')))
     env:
       GITHUB_TOKEN: $(PersonalGithubToken)
   - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
       macos_15:
         imageName: 'macOS-15'
         node: '20.18.0'
+        ptrcompress: false
 
   pool:
     vmImage: $(imageName)
@@ -72,3 +73,8 @@ jobs:
     condition: not(contains(variables['Agent.JobName'], 'linux'))
     env:
       GITHUB_TOKEN: $(PersonalGithubToken)
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: 'out/Release/node'
+      artifact: 'node'
+      publishLocation: pipeline

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,54 +3,56 @@ jobs:
   timeoutInMinutes: 0
   strategy:
     matrix:
+      # We currently build this outside Azure because it is so slow it goes over the 6h job limit there.
       # linux_arm64:
       #   imageName: 'ubuntu-20.04'
       #   arch: 'linux/arm64'
       #   node: '20.18.0'
 
-      # linux_amd64:
-      #   imageName: 'ubuntu-20.04'
-      #   arch: 'linux/amd64'
-      #   node: '20.18.0'
-      #   ptrcompress: false
+      linux_amd64:
+        imageName: 'ubuntu-20.04'
+        arch: 'linux/amd64'
+        node: '20.18.0'
+        ptrcompress: false
 
-      # linux_amd64_ptrc:
-      #   imageName: 'ubuntu-20.04'
-      #   arch: 'linux/amd64'
-      #   node: '20.18.0'
-      #   ptrcompress: true
+      linux_amd64_ptrc:
+        imageName: 'ubuntu-20.04'
+        arch: 'linux/amd64'
+        node: '20.18.0'
+        ptrcompress: true
 
-      # windows_2019:
-      #   imageName: 'windows-2019'
-      #   node: '20.18.0'
-      #   ptrcompress: false
-      # windows_2019_ptrc:
-      #   imageName: 'windows-2019'
-      #   node: '20.18.0'
-      #   ptrcompress: true
+      windows_2019:
+        imageName: 'windows-2019'
+        node: '20.18.0'
+        ptrcompress: false
+      windows_2019_ptrc:
+        imageName: 'windows-2019'
+        node: '20.18.0'
+        ptrcompress: true
 
       macos_arm64:
         imageName: 'macOS-15'
         node: '20.18.0'
         arch: 'arm64'
         ptrcompress: false
+      macos_x64:
+        imageName: 'macOS-15'
+        node: '20.18.0'
+        arch: 'x64'
+        ptrcompress: false
+
+      # Pointer Compression builds are failing on MacOS with 20.18.0, have not dug into why
       # macos_arm64_ptrc:
       #   imageName: 'macOS-15'
       #   node: '20.18.0'
       #   arch: 'arm64'
       #   ptrcompress: true
-
-      # macos_x64:
-      #   imageName: 'macOS-15'
-      #   node: '20.18.0'
-      #   arch: 'x64'
-      #   ptrcompress: false
       # macos_x64_ptrc:
       #   imageName: 'macOS-15'
       #   node: '20.18.0'
       #   arch: 'x64'
       #   ptrcompress: true
-      
+
   pool:
     vmImage: $(imageName)
   steps:
@@ -78,9 +80,7 @@ jobs:
     displayName: setup docker for multi platform
     condition: contains(variables['Agent.JobName'], 'linux')
   ## linux and macos builds
-  # TODO replace this line
-  # - script: node js2bin.js --ci --container=true --pointer-compress=$(ptrcompress) --node=$(node) --size=6MB --size=4MB --upload --clean --arch=${ARCH}
-  - script: node js2bin.js --ci --container=true --pointer-compress=$(ptrcompress) --node=$(node) --size=6MB --clean --arch=${ARCH}
+  - script: node js2bin.js --ci --container=true --pointer-compress=$(ptrcompress) --node=$(node) --size=6MB --size=4MB --upload --clean --arch=${ARCH}
     displayName: Build base node binaries linux or macos
     condition: or(contains(variables['Agent.JobName'], 'linux'), contains(variables['Agent.JobName'], 'macos'))
     env:
@@ -92,8 +92,3 @@ jobs:
     condition: not(or(contains(variables['Agent.JobName'], 'linux'), contains(variables['Agent.JobName'], 'macos')))
     env:
       GITHUB_TOKEN: $(PersonalGithubToken)
-  - task: PublishPipelineArtifact@1
-    inputs:
-      targetPath: 'build/node-v20.18.0/out/Release/node'
-      artifact: 'node'
-      publishLocation: pipeline

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,40 +3,36 @@ jobs:
   timeoutInMinutes: 0
   strategy:
     matrix:
-      linux_arm64:
-        imageName: 'ubuntu-20.04'
-        arch: 'linux/arm64'
+      #linux_arm64:
+      #  imageName: 'ubuntu-20.04'
+      #  arch: 'linux/arm64'
+      #  node: '20.18.0'
+
+      #linux_amd64:
+      #  imageName: 'ubuntu-20.04'
+      #  arch: 'linux/amd64'
+      #  node: '20.18.0'
+      #  ptrcompress: false
+
+      #linux_amd64_ptrc:
+      #  imageName: 'ubuntu-20.04'
+      #  arch: 'linux/amd64'
+      #  node: '20.18.0'
+      #  ptrcompress: true
+
+      #windows_2019:
+      #  imageName: 'windows-2019'
+      #  node: '20.18.0'
+      #  ptrcompress: false
+      #windows_2019_ptrc:
+      #  imageName: 'windows-2019'
+      #  node: '20.18.0'
+      #  ptrcompress: true
+
+      macos_15:
+        imageName: 'macOS-15'
         node: '20.18.0'
 
-      linux_amd64:
-        imageName: 'ubuntu-20.04'
-        arch: 'linux/amd64'
-        node: '20.18.0'
-        ptrcompress: false
-
-      linux_amd64_ptrc:
-        imageName: 'ubuntu-20.04'
-        arch: 'linux/amd64'
-        node: '20.18.0'
-        ptrcompress: true
-
-      windows_2019:
-        imageName: 'windows-2019'
-        node: '20.18.0'
-        ptrcompress: false
-      windows_2019_ptrc:
-        imageName: 'windows-2019'
-        node: '20.18.0'
-        ptrcompress: true
-
-      # mac:
-      #   imageName: 'macos-10.14'
-      #   node: '18.15.0'
-
-      # windows_2015:
-      #   imageName: 'vs2017-win2016'
-#      alpine:
-#        imageName: 'ubuntu-16.04'
   pool:
     vmImage: $(imageName)
   steps:

--- a/js2bin.js
+++ b/js2bin.js
@@ -13,8 +13,8 @@ command-args: take the form of --name=value
 --build: embed your application into the precompiled NodeJS binary.
   --node:     NodeJS version(s) to use, can specify more than one. 
               e.g. --node=10.16.0 --node=12.4.0
-  --platform: Platform(s) to build for, can specifiy more than one. 
-              e.g. --platform=linux --plaform=darwin
+  --platform: Platform(s) to build for, can specify more than one.
+              e.g. --platform=linux --platform=darwin
   --app:      Path to your (bundled) application. 
               e.g. --app=/path/to/app/index.js
   --name:     (opt) Application name
@@ -24,12 +24,11 @@ command-args: take the form of --name=value
   --cache     (opt) Cache any pre-built binaries used, to avoid redownload
   --arch:     (opt) Architecture to build for
 
-
 --ci: build NodeJS with preallocated space for embedding applications
   --node: NodeJS version to build from source, can specify more than one. 
           e.g. --node=10.16.0
   --size: Amount of preallocated space, can specify more than one. 
-          e.g. --size=2MB --size==4MB
+          e.g. --size=2MB --size=4MB
   --dir:       (opt) Working directory, if not specified use cwd
   --cache:     (opt) whether to keep build in the cache (to be reused by --build)
   --upload:    (opt) whether to upload node build to github releases

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -3,7 +3,6 @@ const { log, download, upload, fetch, mkdirp, rmrf, copyFileAsync, runCommand, r
 const { gzipSync, createGunzip } = require('zlib');
 const { join, dirname, basename, resolve } = require('path');
 const fs = require('fs');
-const path = require('path');
 const os = require('os');
 const tar = require('tar-fs');
 const pkg = require('../package.json');
@@ -140,9 +139,6 @@ class NodeJsBuilder {
       Authorization: 'token ' + process.env.GITHUB_TOKEN
     };
     return p
-      // TODO use $BUILD_REPOSITORY_URI? and/or allow for command line option to set this?
-      // Guessing that will look like https://github.com/criblio/js2bin.git and we will have to massage it
-      // See https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
       .then(() => fetch(`https://api.github.com/repos/criblio/js2bin/releases/tags/v${pkg.version}`, headers))
       .then(JSON.parse)
       .then(p => p.upload_url.split('{')[0])


### PR DESCRIPTION
In the Azure pipeline config:
1. Commented out `linux_arm64` build because it is so slow in Azure that it exceeds the 6h time limit and we have to build it elsewhere.
2. Added `macos_arm64` and `macos_x64` builds. Also added `_ptrc` builds but commented them out because they fail for 20.18.0 and we can figure that out in the future if/when it becomes a higher priority.
3. Added a variable `ci_args` that conditionally includes `--upload` when we are *not* doing a PR build. This keeps `js2bin` from trying and failing to upload the binaries during a PR build (and thus failing the build), but it will still do it after we merge to `master`.
4. Genericized the appropriate linux steps to linux + macos.
5. Saved the built binaries as artifacts on the build job. To achieve this we added the `--cache` option to `js2bin` so that all built binaries are saved to the `cache` directory with unique, descriptive names and then that directory is picked up by a new `PublishPipelineArtifact@1` task.

In `NodeBuilder.js`:
1. Enhanced the existing special case for `isDarwin` to get the CPU arch name that the compiler likes (it likes `x86_64`, not `x84`), and provide that to `configure` and `make` as needed. This allows us to cross-compile to `arm64` on the `x86_64` Azure hosted agent.