### PR TITLE
Upgraded nodejs version to 22.14.0 and fixed memory leak

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -15,14 +15,24 @@ RUN sed -i 's/mirror.centos.org/vault.centos.org/g' /etc/yum.repos.d/*.repo && \
    
 # use node 10 as it's guaranteed to run on CentOS6
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
-    yum install -y devtoolset-10 python36 wget patch && \
+    yum install -y devtoolset-10 bzip2-devel libffi-devel patch wget zlib-devel && \
     wget -q https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-x64.tar.gz && \
     tar -xf node-v10.23.0-linux-x64.tar.gz && \ 
     rm node-v10.23.0-linux-x64.tar.gz && \
     ln -s /node-v10.23.0-linux-x64/bin/node /bin/node && \ 
     ln -s /node-v10.23.0-linux-x64/bin/npm /bin/npm 
 
+# Build and install Python 3.9 as a prerequisite for building Node.js 24
+RUN PYTHON_VERSION=3.9.22 && \
+    wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz && \
+    tar -xvf Python-$PYTHON_VERSION.tgz && \
+    cd Python-$PYTHON_VERSION && \
+    ./configure --prefix=/usr/local && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf Python-$PYTHON_VERSION.tgz Python-$PYTHON_VERSION
+
 # before building using this container you need to enable the right slc toolchain ie
 # scl enable devtoolset-8 '<your-build-command-here>'
 # or 'source /opt/rh/devtoolset-8/enable'
-

--- a/Dockerfile.centos7.arm64
+++ b/Dockerfile.centos7.arm64
@@ -15,13 +15,23 @@ RUN sed -i 's|mirror.centos.org/centos|vault.centos.org/altarch|g' /etc/yum.repo
 
 # use node 10 as it's guaranteed to run on CentOS6
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
-    yum install -y devtoolset-10 python36 wget patch && \
+    yum install -y devtoolset-10 bzip2-devel libffi-devel patch wget zlib-devel && \
     wget -q https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-arm64.tar.gz && \
     gunzip node-v10.23.0-linux-arm64.tar.gz && tar xf node-v10.23.0-linux-arm64.tar && rm node-v10.23.0-linux-arm64.tar && \
     ln -s /node-v10.23.0-linux-arm64/bin/node /bin/node && \ 
-    ln -s /node-v10.23.0-linux-arm64/bin/npm /bin/npm && \
-    ln -fs /usr/bin/python3 /usr/bin/python 
+    ln -s /node-v10.23.0-linux-arm64/bin/npm /bin/npm
+
+# Build and install Python 3.9 as a prerequisite for building Node.js 24
+RUN PYTHON_VERSION=3.9.22 && \
+    wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz && \
+    tar -xvf Python-$PYTHON_VERSION.tgz && \
+    cd Python-$PYTHON_VERSION && \
+    ./configure --prefix=/usr/local && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf Python-$PYTHON_VERSION.tgz Python-$PYTHON_VERSION && \
+    ln -fs /usr/bin/python3 /usr/bin/python
 
 # to buid using this container you need to enable the right slc toolchain ie
 # scl enable devtoolset-8 '<your-build-command-here>'
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,14 +21,15 @@ jobs:
         node: '22.14.0'
         ptrcompress: true
 
-      windows_2022:
-        imageName: 'windows-2022'
-        node: '22.14.0'
-        ptrcompress: false
-      windows_2022_ptrc:
-        imageName: 'windows-2022'
-        node: '22.14.0'
-        ptrcompress: true
+      # We currently build this outside of Azure due to storage limitations on Azure Pipelines hosted agents.
+      # windows_2022:
+      #   imageName: 'windows-2022'
+      #   node: '22.14.0'
+      #   ptrcompress: false
+      # windows_2022_ptrc:
+      #   imageName: 'windows-2022'
+      #   node: '22.14.0'
+      #   ptrcompress: true
 
       macos_arm64:
         imageName: 'macOS-15'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,14 @@ jobs:
       xcodebuild -version
     displayName: 'Show Current Xcode Version'
     condition: contains(variables['Agent.JobName'], 'macos')
+  - script: |
+      sudo xcode-select -s /Applications/Xcode_16.2.app
+      xcodebuild -version
+      echo "Currently selected Xcode:"
+      xcode-select -p
+      xcodebuild -version
+    displayName: 'Select Xcode 16.2'
+    condition: contains(variables['Agent.JobName'], 'macos')
   - script: choco install nasm -fy
     displayName: Install Windows Assembler (NASM)
     condition: contains(variables['Agent.JobName'], 'windows')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,32 +12,32 @@ jobs:
       linux_amd64:
         imageName: 'ubuntu-20.04'
         arch: 'linux/amd64'
-        node: '20.18.0'
+        node: '22.14.0'
         ptrcompress: false
 
       linux_amd64_ptrc:
         imageName: 'ubuntu-20.04'
         arch: 'linux/amd64'
-        node: '20.18.0'
+        node: '22.14.0'
         ptrcompress: true
 
-      windows_2019:
-        imageName: 'windows-2019'
-        node: '20.18.0'
+      windows_2022:
+        imageName: 'windows-2022'
+        node: '22.14.0'
         ptrcompress: false
-      windows_2019_ptrc:
-        imageName: 'windows-2019'
-        node: '20.18.0'
+      windows_2022_ptrc:
+        imageName: 'windows-2022'
+        node: '22.14.0'
         ptrcompress: true
 
       macos_arm64:
         imageName: 'macOS-15'
-        node: '20.18.0'
+        node: '22.14.0'
         arch: 'arm64'
         ptrcompress: false
       macos_x64:
         imageName: 'macOS-15'
-        node: '20.18.0'
+        node: '22.14.0'
         arch: 'x64'
         ptrcompress: false
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,6 +79,12 @@ jobs:
   #- script: choco install visualcpp-build-tools --version 14.0.25420.1 -fy && npm config set msvs_version 2015
   #  condition: contains(variables['Agent.JobName'], 'windows_2015')
   #  displayName: Install Windows build dependencies
+  - script: |
+      echo "Currently selected Xcode:"
+      xcode-select -p
+      xcodebuild -version
+    displayName: 'Show Current Xcode Version'
+    condition: contains(variables['Agent.JobName'], 'macos')
   - script: choco install nasm -fy
     displayName: Install Windows Assembler (NASM)
     condition: contains(variables['Agent.JobName'], 'windows')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,11 +15,12 @@ jobs:
         node: '22.14.0'
         ptrcompress: false
 
-      linux_amd64_ptrc:
-        imageName: 'ubuntu-20.04'
-        arch: 'linux/amd64'
-        node: '22.14.0'
-        ptrcompress: true
+      # Pointer Compression builds are failing on Linux
+      # linux_amd64_ptrc:
+      #   imageName: 'ubuntu-20.04'
+      #   arch: 'linux/amd64'
+      #   node: '22.14.0'
+      #   ptrcompress: true
 
       # We currently build this outside of Azure due to storage limitations on Azure Pipelines hosted agents.
       # windows_2022:

--- a/build-builder.sh
+++ b/build-builder.sh
@@ -3,7 +3,7 @@ docker pull moby/buildkit:buildx-stable-1
 if [ $(docker buildx ls | grep js2bin-builder  | wc -l) -eq 0 ]; then
     docker buildx create --name js2bin-builder
 fi
-docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker run --rm --privileged tonistiigi/binfmt --install all
 docker buildx use js2bin-builder
 BUILDER_IMAGE_VERSION="3"
 ARCH=$(uname -m)

--- a/build-builder.sh
+++ b/build-builder.sh
@@ -6,6 +6,11 @@ fi
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 docker buildx use js2bin-builder
 BUILDER_IMAGE_VERSION="3"
+ARCH=$(uname -m)
+if [ "$ARCH" == "x86_64" ]; then
+    echo "WARNING: You are running on an x86_64 host. Cross-compiling Python for arm64 may result in build failures or inconsistent behavior."
+    echo "It is recommended to run this script on an arm64 host if possible."
+fi
 docker buildx build -t "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}-nonx64" --platform linux/arm64/v8 --push -f Dockerfile.centos7.arm64 .
-docker build -t "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}" -f Dockerfile.centos7 .
-docker push "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}"
+docker buildx build -t "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}" --platform linux/amd64 --push -f Dockerfile.centos7 .
+

--- a/build-builder.sh
+++ b/build-builder.sh
@@ -5,7 +5,7 @@ if [ $(docker buildx ls | grep js2bin-builder  | wc -l) -eq 0 ]; then
 fi
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 docker buildx use js2bin-builder
-BUILDER_IMAGE_VERSION="2"
+BUILDER_IMAGE_VERSION="3"
 docker buildx build -t "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}-nonx64" --platform linux/arm64/v8 --push -f Dockerfile.centos7.arm64 .
 docker build -t "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}" -f Dockerfile.centos7 .
 docker push "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}"

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -214,9 +214,9 @@ class NodeJsBuilder {
       this.nodePath('node.gyp'),
       join(this.patchDir, 'node.gyp.patch'));
 
-    await patchFile(
-      this.nodePath('configure.py'),
-      join(this.patchDir, 'configure.py.patch'));
+    // await patchFile(
+    //   this.nodePath('configure.py'),
+    //   join(this.patchDir, 'configure.py.patch'));
 
     isWindows && await patchFile(
       this.nodePath('vcbuild.bat'),

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -268,7 +268,7 @@ class NodeJsBuilder {
   // 4. process mainAppFile (gzip, base64 encode it) - could be a placeholder file
   // 5. kick off ./configure & build
   buildFromSource(uploadBuild, cache, container, arch, ptrCompression) {
-    const makeArgs = isWindows ? ['x64', 'no-cctest'] : [`-j${os.cpus().length}`];
+    const makeArgs = isWindows ? ['x64', 'no-cctest', 'clang-cl'] : [`-j${os.cpus().length}`];
     const configArgs = [];
     if(ptrCompression) {
       if(isWindows) makeArgs.push('v8_ptr_compress');

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -218,9 +218,10 @@ class NodeJsBuilder {
     //   this.nodePath('configure.py'),
     //   join(this.patchDir, 'configure.py.patch'));
 
-    isWindows && await patchFile(
-      this.nodePath('vcbuild.bat'),
-      join(this.patchDir, 'vcbuild.bat.patch'));
+    if (isWindows) {
+      await patchFile(this.nodePath('vcbuild.bat'), join(this.patchDir, 'vcbuild.bat.patch'));
+      await patchFile(this.nodePath('deps', 'v8', 'include', 'v8config.h'), join(this.patchDir, 'v8config.patch'));
+    }
 
     isLinux && await patchFile(
       this.nodePath('deps','cares','config','linux','ares_config.h'),

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -1,7 +1,7 @@
 
 const { log, download, upload, fetch, mkdirp, rmrf, copyFileAsync, runCommand, renameAsync, patchFile } = require('./util');
 const { gzipSync, createGunzip } = require('zlib');
-const { join, dirname, basename, resolve } = require('path');
+const { join, dirname, basename, parse, resolve } = require('path');
 const fs = require('fs');
 const os = require('os');
 const tar = require('tar-fs');
@@ -234,7 +234,10 @@ class NodeJsBuilder {
   }
 
   printDiskUsage() {
-    if (isWindows) { return runCommand('fsutil', ['volume', 'diskfree', 'd:']); }
+    if (isWindows) {
+      const parsedPath = parse(this.resultFile);
+      return runCommand('fsutil', ['volume', 'diskfree', parsedPath.root]);
+    }
     return runCommand('df', ['-h']);
   }
 

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -214,7 +214,7 @@ class NodeJsBuilder {
       this.nodePath('node.gyp'),
       join(this.patchDir, 'node.gyp.patch'));
 
-    // await patchFile(
+    // await patchFile( 
     //   this.nodePath('configure.py'),
     //   join(this.patchDir, 'configure.py.patch'));
 

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -237,19 +237,19 @@ class NodeJsBuilder {
     return runCommand('df', ['-h']);
   }
 
-  buildInContainer() {
+  buildInContainer(ptrCompression) {
     const containerTag = `cribl/js2bin-builder:${this.builderImageVersion}`;
     return runCommand(
         'docker', ['run',
           '-v', `${process.cwd()}:/js2bin/`,
           '-t', containerTag,
           '/bin/bash', '-c',
-        `source /opt/rh/devtoolset-10/enable && cd /js2bin && npm install && ./js2bin.js --ci --node=${this.version} --size=${this.placeHolderSizeMB}MB`
+        `source /opt/rh/devtoolset-10/enable && cd /js2bin && npm install && ./js2bin.js --ci --node=${this.version} --size=${this.placeHolderSizeMB}MB ${ptrCompression ? '--pointer-compress=true' : ''}`
         ]
       );
   }
 
-  buildInContainerNonX64(arch) {
+  buildInContainerNonX64(arch, ptrCompression) {
     const containerTag = `cribl/js2bin-builder:${this.builderImageVersion}-nonx64`;
     return runCommand(
         'docker', ['run',
@@ -257,7 +257,7 @@ class NodeJsBuilder {
           '-v', `${process.cwd()}:/js2bin/`,
           '-t', containerTag,
           '/bin/bash', '-c',
-          `source /opt/rh/devtoolset-10/enable && cd /js2bin && npm install && ./js2bin.js --ci --node=${this.version} --size=${this.placeHolderSizeMB}MB`
+          `source /opt/rh/devtoolset-10/enable && cd /js2bin && npm install && ./js2bin.js --ci --node=${this.version} --size=${this.placeHolderSizeMB}MB ${ptrCompression ? '--pointer-compress=true' : ''}`
         ]
       );
   }
@@ -300,9 +300,9 @@ class NodeJsBuilder {
             .then(() => runCommand(this.make, makeArgs, this.nodeSrcDir, cfgMakeEnv));
         }
         if (arch !== 'linux/amd64') {
-          return this.buildInContainerNonX64(arch);
+          return this.buildInContainerNonX64(arch, ptrCompression);
         }
-        return this.buildInContainer();
+        return this.buildInContainer(ptrCompression);
       })
       .then(() => this.uploadNodeBinary(undefined, uploadBuild, cache, arch, ptrCompression))
       .then(() => this.printDiskUsage())

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -268,7 +268,7 @@ class NodeJsBuilder {
   // 4. process mainAppFile (gzip, base64 encode it) - could be a placeholder file
   // 5. kick off ./configure & build
   buildFromSource(uploadBuild, cache, container, arch, ptrCompression) {
-    const makeArgs = isWindows ? ['x64', 'no-cctest', 'clang-cl'] : [`-j${os.cpus().length}`];
+    const makeArgs = isWindows ? ['x64', 'no-cctest'] : [`-j${os.cpus().length}`];
     const configArgs = [];
     if(ptrCompression) {
       if(isWindows) makeArgs.push('v8_ptr_compress');

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -198,34 +198,28 @@ class NodeJsBuilder {
   }
 
   async patchThirdPartyMain() {
-    await patchFile(
-      this.nodePath('lib', 'internal', 'main', 'run_third_party_main.js'),
-      join(this.patchDir, 'run_third_party_main.js.patch'));
-    await patchFile(
-      this.nodePath('src', 'node.cc'),
-      join(this.patchDir, 'node.cc.patch'));
-    await patchFile(
-      this.nodePath('deps', 'uv', 'src', 'win', 'fs-event.c'),
-      join(this.patchDir, 'fs-event.c.patch'));
+    await patchFile(this.nodeSrcDir, join(this.patchDir, 'run_third_party_main.js.patch'));
+    await patchFile(this.nodeSrcDir, join(this.patchDir, 'node.cc.patch'));
+    await patchFile(this.nodeSrcDir, join(this.patchDir, 'fs-event.c.patch'));
   }
 
   async patchNodeCompileIssues() {
-    await patchFile(
-      this.nodePath('node.gyp'),
-      join(this.patchDir, 'node.gyp.patch'));
-
-    // await patchFile( 
-    //   this.nodePath('configure.py'),
-    //   join(this.patchDir, 'configure.py.patch'));
+    await patchFile(this.nodeSrcDir, join(this.patchDir, 'node.gyp.patch'));
 
     if (isWindows) {
-      await patchFile(this.nodePath('vcbuild.bat'), join(this.patchDir, 'vcbuild.bat.patch'));
-      await patchFile(this.nodePath('deps', 'v8', 'include', 'v8config.h'), join(this.patchDir, 'v8config.patch'));
+      await patchFile(this.nodeSrcDir, join(this.patchDir, 'vcbuild.bat.patch'));
+      await patchFile(this.nodeSrcDir, join(this.patchDir, 'v8config.patch'));
+      // The following patches fix the memory leak when using pointer compression
+      // They are fixing both Linux and Windows, however, we only apply them to Windows to keep the blast radius small
+      await patchFile(this.nodeSrcDir, join(this.patchDir, 'configure.py.patch'));
+      await patchFile(this.nodeSrcDir, join(this.patchDir, 'features.gypi.patch'));
+      await patchFile(this.nodeSrcDir, join(this.patchDir, 'node_buffer.cc.patch'));
+      await patchFile(this.nodeSrcDir, join(this.patchDir, 'v8_backing_store_callers.patch'));
     }
 
-    isLinux && await patchFile(
-      this.nodePath('deps','cares','config','linux','ares_config.h'),
-      join(this.patchDir, 'no_rand_on_glibc.patch'));
+    if (isLinux) {
+      await patchFile(this.nodeSrcDir, join(this.patchDir, 'no_rand_on_glibc.patch'));
+    }
   }
 
   async applyPatches() {

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -72,7 +72,7 @@ class NodeJsBuilder {
     this.cacheDir = join(cwd || process.cwd(), 'cache');
     this.resultFile = isWindows ? join(this.nodeSrcDir, 'Release', 'node.exe') : join(this.nodeSrcDir, 'out', 'Release', 'node');
     this.placeHolderSizeMB = -1;
-    this.builderImageVersion = 2;
+    this.builderImageVersion = 3;
   }
 
   static platform() {

--- a/src/patch/22.14.0/configure.py.patch
+++ b/src/patch/22.14.0/configure.py.patch
@@ -1,0 +1,13 @@
+--- a/configure.py
++++ b/configure.py
+@@ -1598,7 +1598,9 @@ def configure_v8(o):
+   o['variables']['v8_use_siphash'] = 0 if options.without_siphash else 1
+   o['variables']['v8_enable_maglev'] = 1 if options.v8_enable_maglev else 0
+   o['variables']['v8_enable_pointer_compression'] = 1 if options.enable_pointer_compression else 0
+-  o['variables']['v8_enable_sandbox'] = 1 if options.enable_pointer_compression else 0
++
++  # o['variables']['v8_enable_sandbox'] = 1 if options.enable_pointer_compression else 0
++
+   o['variables']['v8_enable_31bit_smis_on_64bit_arch'] = 1 if options.enable_pointer_compression else 0
+   o['variables']['v8_enable_shared_ro_heap'] = 0 if options.enable_pointer_compression or options.disable_shared_ro_heap else 1
+   o['variables']['v8_enable_extensible_ro_snapshot'] = 0

--- a/src/patch/22.14.0/configure.py.patch
+++ b/src/patch/22.14.0/configure.py.patch
@@ -1,13 +1,14 @@
 --- a/configure.py
 +++ b/configure.py
-@@ -1598,7 +1598,9 @@ def configure_v8(o):
-   o['variables']['v8_use_siphash'] = 0 if options.without_siphash else 1
+@@ -1657,8 +1657,10 @@ def configure_v8(o, configs):
    o['variables']['v8_enable_maglev'] = 1 if options.v8_enable_maglev else 0
    o['variables']['v8_enable_pointer_compression'] = 1 if options.enable_pointer_compression else 0
--  o['variables']['v8_enable_sandbox'] = 1 if options.enable_pointer_compression else 0
-+
-+  # o['variables']['v8_enable_sandbox'] = 1 if options.enable_pointer_compression else 0
-+
+   o['variables']['v8_enable_sandbox'] = 1 if options.enable_pointer_compression else 0
++  o['variables']['v8_enable_pointer_compression_shared_cage'] = 1 if options.enable_pointer_compression else 0
++  o['variables']['v8_enable_external_code_space'] = 1 if options.enable_pointer_compression else 0
++  o['variables']['v8_enable_shared_ro_heap'] = 0 if options.disable_shared_ro_heap else 1
    o['variables']['v8_enable_31bit_smis_on_64bit_arch'] = 1 if options.enable_pointer_compression else 0
-   o['variables']['v8_enable_shared_ro_heap'] = 0 if options.enable_pointer_compression or options.disable_shared_ro_heap else 1
+-  o['variables']['v8_enable_shared_ro_heap'] = 0 if options.enable_pointer_compression or options.disable_shared_ro_heap else 1
    o['variables']['v8_enable_extensible_ro_snapshot'] = 0
+   o['variables']['v8_trace_maps'] = 1 if options.trace_maps else 0
+   o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)

--- a/src/patch/22.14.0/features.gypi.patch
+++ b/src/patch/22.14.0/features.gypi.patch
@@ -1,0 +1,22 @@
+--- a/tools/v8_gypfiles/features.gypi
++++ b/tools/v8_gypfiles/features.gypi
+@@ -157,6 +157,9 @@
+     'v8_enable_pointer_compression_shared_cage%': 0,
+     'v8_enable_31bit_smis_on_64bit_arch%': 0,
+ 
++    # Enable external code space (sets -dV8_EXTERNAL_CODE_SPACE).
++    'v8_enable_external_code_space%': 0,
++
+     # Sets -dV8_SHORT_BUILTIN_CALLS
+     'v8_enable_short_builtin_calls%': 0,
+ 
+@@ -384,6 +387,9 @@
+       ['v8_enable_sandbox==1', {
+         'defines': ['V8_ENABLE_SANDBOX',],
+       }],
++      ['v8_enable_external_code_space==1', {
++        'defines': ['V8_EXTERNAL_CODE_SPACE',],
++      }],
+       ['v8_enable_object_print==1', {
+         'defines': ['OBJECT_PRINT',],
+       }],

--- a/src/patch/22.14.0/fs-event.c.patch
+++ b/src/patch/22.14.0/fs-event.c.patch
@@ -1,0 +1,11 @@
+--- a/deps/uv/src/win/fs-event.c
++++ b/deps/uv/src/win/fs-event.c
+@@ -266,6 +266,8 @@ short_path_done:
+     }
+
+     dir_to_watch = dir;
++    uv__free(short_path);
++    short_path = NULL;
+     uv__free(pathw);
+     pathw = NULL;
+   }

--- a/src/patch/22.14.0/no_rand_on_glibc.patch
+++ b/src/patch/22.14.0/no_rand_on_glibc.patch
@@ -1,0 +1,24 @@
+disable usage of <sys/random.h>
+
+--- deps/cares/config/linux/ares_config.h
++++ deps/cares/config/linux/ares_config.h
+@@ -116,7 +116,9 @@
+ #define HAVE_GETNAMEINFO 1
+
+ /* Define to 1 if you have `getrandom` */
++#if defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 25
+ #define HAVE_GETRANDOM 1
++#endif
+
+ /* Define to 1 if you have `getservbyport_r` */
+ #define HAVE_GETSERVBYPORT_R 1
+@@ -329,7 +331,9 @@
+ #define HAVE_SYS_PARAM_H 1
+
+ /* Define to 1 if you have the <sys/random.h> header file. */
++#if defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 25
+ #define HAVE_SYS_RANDOM_H 1
++#endif
+
+ /* Define to 1 if you have the <sys/select.h> header file. */
+ #define HAVE_SYS_SELECT_H 1

--- a/src/patch/22.14.0/no_rand_on_glibc.patch
+++ b/src/patch/22.14.0/no_rand_on_glibc.patch
@@ -1,7 +1,7 @@
 disable usage of <sys/random.h>
 
---- deps/cares/config/linux/ares_config.h
-+++ deps/cares/config/linux/ares_config.h
+--- a/deps/cares/config/linux/ares_config.h
++++ b/deps/cares/config/linux/ares_config.h
 @@ -116,7 +116,9 @@
  #define HAVE_GETNAMEINFO 1
 

--- a/src/patch/22.14.0/node.cc.patch
+++ b/src/patch/22.14.0/node.cc.patch
@@ -1,0 +1,17 @@
+--- src/node.cc
++++ src/node.cc
+@@ -377,6 +377,14 @@ MaybeLocal<Value> StartExecution(Environment* env, StartExecutionCallback cb) {
+     return env->RunSnapshotDeserializeMain();
+   }
+ 
++  // To allow people to extend Node in different ways, this hook allows
++  // one to drop a file lib/_third_party_main.js into the build
++  // directory which will be executed instead of Node's normal loading.
++  if (env->builtin_loader()->Exists("_third_party_main")) {
++    return StartExecution(env, "internal/main/run_third_party_main");
++  }
++
++
+   if (env->worker_context() != nullptr) {
+     return StartExecution(env, "internal/main/worker_thread");
+   }

--- a/src/patch/22.14.0/node.cc.patch
+++ b/src/patch/22.14.0/node.cc.patch
@@ -1,5 +1,5 @@
---- src/node.cc
-+++ src/node.cc
+--- a/src/node.cc
++++ b/src/node.cc
 @@ -377,6 +377,14 @@ MaybeLocal<Value> StartExecution(Environment* env, StartExecutionCallback cb) {
      return env->RunSnapshotDeserializeMain();
    }

--- a/src/patch/22.14.0/node.gyp.patch
+++ b/src/patch/22.14.0/node.gyp.patch
@@ -1,7 +1,7 @@
 disable building of cctest as it (a) it fails to build due to align_alloc and (b) it is just a waste of time
 
---- node.gyp
-+++ node.gyp
+--- a/node.gyp
++++ b/node.gyp
 @@ -1144,7 +1144,7 @@
      }, # fuzz_strings
      {

--- a/src/patch/22.14.0/node.gyp.patch
+++ b/src/patch/22.14.0/node.gyp.patch
@@ -1,0 +1,13 @@
+disable building of cctest as it (a) it fails to build due to align_alloc and (b) it is just a waste of time
+
+--- node.gyp
++++ node.gyp
+@@ -1144,7 +1144,7 @@
+     }, # fuzz_strings
+     {
+       'target_name': 'cctest',
+-      'type': 'executable',
++      'type': 'none',
+ 
+       'dependencies': [
+         '<(node_lib_target_name)',

--- a/src/patch/22.14.0/node_buffer.cc.patch
+++ b/src/patch/22.14.0/node_buffer.cc.patch
@@ -1,0 +1,173 @@
+--- a/src/node_buffer.cc
++++ b/src/node_buffer.cc
+@@ -82,6 +82,100 @@ using v8::Uint32Array;
+ using v8::Uint8Array;
+ using v8::Value;
+ 
++// Helper function to create a sandbox-aware backing store
++std::unique_ptr<BackingStore> CreateBackingStore(
++    Isolate* isolate,
++    void* data,
++    size_t byte_length,
++    BackingStore::DeleterCallback deleter,
++    void* deleter_data) {
++#ifdef V8_ENABLE_SANDBOX
++  // When V8 sandbox is enabled, we need to allocate memory through V8's
++  // ArrayBuffer::Allocator to ensure it's within the sandbox memory region.
++  // This creates a new backing store by first allocating memory through V8,
++  // copying any existing data into it, and setting up proper deallocation.
++  ArrayBuffer::Allocator* allocator = isolate->GetArrayBufferAllocator();
++  if (!allocator) {
++    fprintf(stderr, "Failed to get array buffer allocator\n");
++    return nullptr;
++  }
++  
++  // Allocate memory using the isolate's allocator to ensure it's within the sandbox
++  void* allocated_memory = allocator->Allocate(byte_length);
++  if (!allocated_memory) {
++    fprintf(stderr, "Failed to allocate memory\n");
++    return nullptr;
++  }
++
++  // If we have data to copy, copy it into the allocated memory
++  if (data != nullptr) {
++    memcpy(allocated_memory, data, byte_length);
++  }
++
++  // Define a structure to hold all the information needed for proper memory cleanup
++  struct BackingStoreDeleterContext {
++    BackingStore::DeleterCallback original_deleter;  // Original callback to free external resources
++    void* original_deleter_data;                     // Data passed to the original deleter
++    void* original_data;                             // Original data pointer
++    ArrayBuffer::Allocator* allocator;               // Allocator used to free the memory
++  };
++  
++  std::unique_ptr<BackingStoreDeleterContext> deletion_context;
++  if (deleter != nullptr) {
++    deletion_context = std::make_unique<BackingStoreDeleterContext>(BackingStoreDeleterContext{
++      deleter, deleter_data, data, allocator
++    });
++  }
++
++  std::unique_ptr<BackingStore> store;
++  if (deleter != nullptr) {
++    store = ArrayBuffer::NewBackingStore(
++      allocated_memory, 
++      byte_length,
++      [](void* data, size_t length, void* deletion_context_ptr) {
++        auto* context = static_cast<BackingStoreDeleterContext*>(deletion_context_ptr);
++        // Call the original deleter to clean up any external resources
++        context->original_deleter(context->original_data, length, context->original_deleter_data);
++        // Free the memory using the allocator
++        context->allocator->Free(data, length);
++      },
++      deletion_context.get()  // Pass the deletion context for memory cleanup
++    );
++  } else {
++    store = ArrayBuffer::NewBackingStore(
++      allocated_memory, 
++      byte_length,
++      [](void* data, size_t length, void* allocator_ptr) {
++        auto* allocator = static_cast<ArrayBuffer::Allocator*>(allocator_ptr);
++        // Free the memory using the allocator
++        allocator->Free(data, length);
++      },
++      static_cast<void*>(allocator)  // Pass the allocator for memory cleanup
++    );
++  }
++
++  // Handle the case where backing store creation fails
++  if (!store) {
++    fprintf(stderr, "Failed to create backing store\n");
++    allocator->Free(allocated_memory, byte_length);
++    return nullptr;
++  }
++
++  // Transfer ownership of the deletion context to the BackingStore
++  // This ensures the deletion context lives as long as the BackingStore and is properly cleaned up
++  deletion_context.release();
++
++  return store;
++#else
++  // When sandbox is not enabled, we can directly create the backing store
++  if (deleter != nullptr) {
++    return ArrayBuffer::NewBackingStore(data, byte_length, deleter, deleter_data);
++  } else {
++    return ArrayBuffer::NewBackingStore(isolate, byte_length);
++  }
++#endif
++}
++
+ namespace {
+ 
+ class CallbackInfo : public Cleanable {
+@@ -123,7 +217,7 @@ Local<ArrayBuffer> CallbackInfo::CreateTrackedArrayBuffer(
+ 
+   CallbackInfo* self = new CallbackInfo(env, callback, data, hint);
+   std::unique_ptr<BackingStore> bs =
+-      ArrayBuffer::NewBackingStore(data, length, [](void*, size_t, void* arg) {
++      CreateBackingStore(env->isolate(), data, length, [](void*, size_t, void* arg) {
+         static_cast<CallbackInfo*>(arg)->OnBackingStoreFree();
+       }, self);
+   Local<ArrayBuffer> ab = ArrayBuffer::New(env->isolate(), std::move(bs));
+@@ -310,7 +404,7 @@ MaybeLocal<Object> New(Isolate* isolate,
+   std::unique_ptr<BackingStore> store;
+ 
+   if (length > 0) {
+-    store = ArrayBuffer::NewBackingStore(isolate, length);
++    store = CreateBackingStore(isolate, nullptr, length, nullptr, nullptr);
+ 
+     if (!store) [[unlikely]] {
+       THROW_ERR_MEMORY_ALLOCATION_FAILED(isolate);
+@@ -328,7 +422,7 @@ MaybeLocal<Object> New(Isolate* isolate,
+     if (actual > 0) [[likely]] {
+       if (actual < length) {
+         std::unique_ptr<BackingStore> old_store = std::move(store);
+-        store = ArrayBuffer::NewBackingStore(isolate, actual);
++        store = CreateBackingStore(isolate, nullptr, actual, nullptr, nullptr);
+         memcpy(static_cast<char*>(store->Data()),
+                static_cast<char*>(old_store->Data()),
+                actual);
+@@ -374,7 +468,7 @@ MaybeLocal<Object> New(Environment* env, size_t length) {
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+     std::unique_ptr<BackingStore> bs =
+-        ArrayBuffer::NewBackingStore(isolate, length);
++        CreateBackingStore(isolate, nullptr, length, nullptr, nullptr);
+ 
+     CHECK(bs);
+ 
+@@ -417,7 +511,7 @@ MaybeLocal<Object> Copy(Environment* env, const char* data, size_t length) {
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+     std::unique_ptr<BackingStore> bs =
+-        ArrayBuffer::NewBackingStore(isolate, length);
++        CreateBackingStore(isolate, nullptr, length, nullptr, nullptr);
+ 
+     CHECK(bs);
+ 
+@@ -518,7 +612,7 @@ MaybeLocal<Object> New(Environment* env,
+     free(data);
+   };
+   std::unique_ptr<BackingStore> bs =
+-      v8::ArrayBuffer::NewBackingStore(data, length, free_callback, nullptr);
++      CreateBackingStore(env->isolate(), data, length, free_callback, nullptr);
+ 
+   Local<ArrayBuffer> ab = v8::ArrayBuffer::New(env->isolate(), std::move(bs));
+ 
+@@ -1235,10 +1329,11 @@ void GetZeroFillToggle(const FunctionCallbackInfo<Value>& args) {
+   } else {
+     uint32_t* zero_fill_field = allocator->zero_fill_field();
+     std::unique_ptr<BackingStore> backing =
+-        ArrayBuffer::NewBackingStore(zero_fill_field,
+-                                     sizeof(*zero_fill_field),
+-                                     [](void*, size_t, void*) {},
+-                                     nullptr);
++        CreateBackingStore(env->isolate(),
++                         zero_fill_field,
++                         sizeof(*zero_fill_field),
++                         [](void*, size_t, void*) {},
++                         nullptr);
+     ab = ArrayBuffer::New(env->isolate(), std::move(backing));
+   }
+ 

--- a/src/patch/22.14.0/run_third_party_main.js.patch
+++ b/src/patch/22.14.0/run_third_party_main.js.patch
@@ -1,0 +1,17 @@
+--- /dev/null
++++ lib/internal/main/run_third_party_main.js
+@@ -0,0 +1,14 @@
++'use strict';
++
++const {
++  prepareMainThreadExecution,
++  markBootstrapComplete
++} = require('internal/process/pre_execution');
++
++prepareMainThreadExecution();
++markBootstrapComplete();
++
++// Legacy _third_party_main.js support
++process.nextTick(() => {
++  require('_third_party_main');
++});

--- a/src/patch/22.14.0/run_third_party_main.js.patch
+++ b/src/patch/22.14.0/run_third_party_main.js.patch
@@ -1,5 +1,5 @@
 --- /dev/null
-+++ lib/internal/main/run_third_party_main.js
++++ b/lib/internal/main/run_third_party_main.js
 @@ -0,0 +1,14 @@
 +'use strict';
 +

--- a/src/patch/22.14.0/v8_backing_store_callers.patch
+++ b/src/patch/22.14.0/v8_backing_store_callers.patch
@@ -1,0 +1,732 @@
+--- a/src/aliased_struct-inl.h
++++ b/src/aliased_struct-inl.h
+@@ -6,6 +6,7 @@
+ #include "aliased_struct.h"
+ #include "v8.h"
+ #include <memory>
++#include "node_buffer.h"
+ 
+ namespace node {
+ 
+@@ -15,7 +16,7 @@ AliasedStruct<T>::AliasedStruct(v8::Isolate* isolate, Args&&... args)
+     : isolate_(isolate) {
+   const v8::HandleScope handle_scope(isolate);
+ 
+-  store_ = v8::ArrayBuffer::NewBackingStore(isolate, sizeof(T));
++  store_ = node::Buffer::CreateBackingStore(isolate, nullptr, sizeof(T), nullptr, nullptr);
+   ptr_ = new (store_->Data()) T(std::forward<Args>(args)...);
+   DCHECK_NOT_NULL(ptr_);
+
+
+--- a/src/crypto/crypto_cipher.cc
++++ b/src/crypto/crypto_cipher.cc
+@@ -776,7 +776,7 @@ CipherBase::UpdateResult CipherBase::Update(
+ 
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env()->isolate_data());
+-    *out = ArrayBuffer::NewBackingStore(env()->isolate(), buf_len);
++    *out = node::Buffer::CreateBackingStore(env()->isolate(), nullptr, buf_len, nullptr, nullptr);
+   }
+ 
+   buffer = {
+@@ -789,10 +789,10 @@ CipherBase::UpdateResult CipherBase::Update(
+ 
+   CHECK_LE(static_cast<size_t>(buf_len), (*out)->ByteLength());
+   if (buf_len == 0) {
+-    *out = ArrayBuffer::NewBackingStore(env()->isolate(), 0);
++    *out = node::Buffer::CreateBackingStore(env()->isolate(), nullptr, 0, nullptr, nullptr);
+   } else if (static_cast<size_t>(buf_len) != (*out)->ByteLength()) {
+     std::unique_ptr<BackingStore> old_out = std::move(*out);
+-    *out = ArrayBuffer::NewBackingStore(env()->isolate(), buf_len);
++    *out = node::Buffer::CreateBackingStore(env()->isolate(), nullptr, buf_len, nullptr, nullptr);
+     memcpy(static_cast<char*>((*out)->Data()),
+            static_cast<char*>(old_out->Data()),
+            buf_len);
+@@ -856,8 +856,8 @@ bool CipherBase::Final(std::unique_ptr<BackingStore>* out) {
+ 
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env()->isolate_data());
+-    *out = ArrayBuffer::NewBackingStore(
+-        env()->isolate(), static_cast<size_t>(ctx_.getBlockSize()));
++    *out = node::Buffer::CreateBackingStore(
++        env()->isolate(), nullptr, static_cast<size_t>(ctx_.getBlockSize()), nullptr, nullptr);
+   }
+ 
+   if (kind_ == kDecipher &&
+@@ -878,7 +878,7 @@ bool CipherBase::Final(std::unique_ptr<BackingStore>* out) {
+   bool ok;
+   if (kind_ == kDecipher && mode == EVP_CIPH_CCM_MODE) {
+     ok = !pending_auth_failed_;
+-    *out = ArrayBuffer::NewBackingStore(env()->isolate(), 0);
++    *out = node::Buffer::CreateBackingStore(env()->isolate(), nullptr, 0, nullptr, nullptr);
+   } else {
+     int out_len = (*out)->ByteLength();
+     ok = ctx_.update(
+@@ -886,10 +886,10 @@ bool CipherBase::Final(std::unique_ptr<BackingStore>* out) {
+ 
+     CHECK_LE(static_cast<size_t>(out_len), (*out)->ByteLength());
+     if (out_len == 0) {
+-      *out = ArrayBuffer::NewBackingStore(env()->isolate(), 0);
++      *out = node::Buffer::CreateBackingStore(env()->isolate(), nullptr, 0, nullptr, nullptr);
+     } else if (static_cast<size_t>(out_len) != (*out)->ByteLength()) {
+       std::unique_ptr<BackingStore> old_out = std::move(*out);
+-      *out = ArrayBuffer::NewBackingStore(env()->isolate(), out_len);
++      *out = node::Buffer::CreateBackingStore(env()->isolate(), nullptr, out_len, nullptr, nullptr);
+       memcpy(static_cast<char*>((*out)->Data()),
+              static_cast<char*>(old_out->Data()),
+              out_len);
+@@ -978,7 +978,7 @@ bool PublicKeyCipher::Cipher(
+ 
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    *out = ArrayBuffer::NewBackingStore(env->isolate(), out_len);
++    *out = node::Buffer::CreateBackingStore(env->isolate(), nullptr, out_len, nullptr, nullptr);
+   }
+ 
+   if (EVP_PKEY_cipher(
+@@ -992,10 +992,10 @@ bool PublicKeyCipher::Cipher(
+ 
+   CHECK_LE(out_len, (*out)->ByteLength());
+   if (out_len == 0) {
+-    *out = ArrayBuffer::NewBackingStore(env->isolate(), 0);
++    *out = node::Buffer::CreateBackingStore(env->isolate(), nullptr, 0, nullptr, nullptr);
+   } else if (out_len != (*out)->ByteLength()) {
+     std::unique_ptr<BackingStore> old_out = std::move(*out);
+-    *out = ArrayBuffer::NewBackingStore(env->isolate(), out_len);
++    *out = node::Buffer::CreateBackingStore(env->isolate(), nullptr, out_len, nullptr, nullptr);
+     memcpy(static_cast<char*>((*out)->Data()),
+            static_cast<char*>(old_out->Data()),
+            out_len);
+
+
+--- a/src/crypto/crypto_common.cc
++++ b/src/crypto/crypto_common.cc
+@@ -310,7 +310,7 @@ MaybeLocal<Object> ECPointToBuffer(Environment* env,
+   std::unique_ptr<BackingStore> bs;
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    bs = ArrayBuffer::NewBackingStore(env->isolate(), len);
++    bs = node::Buffer::CreateBackingStore(env->isolate(), nullptr, len, nullptr, nullptr);
+   }
+ 
+   len = EC_POINT_point2oct(group,
+
+
+--- a/src/crypto/crypto_dh.cc
++++ b/src/crypto/crypto_dh.cc
+@@ -11,6 +11,7 @@
+ #include "openssl/dh.h"
+ #include "threadpoolwork-inl.h"
+ #include "v8.h"
++#include "node_buffer.h"
+ 
+ namespace node {
+ 
+@@ -53,7 +54,8 @@ void DiffieHellman::MemoryInfo(MemoryTracker* tracker) const {
+ 
+ namespace {
+ MaybeLocal<Value> DataPointerToBuffer(Environment* env, DataPointer&& data) {
+-  auto backing = ArrayBuffer::NewBackingStore(
++  auto backing = node::Buffer::CreateBackingStore(
++      env->isolate(),
+       data.get(),
+       data.size(),
+       [](void* data, size_t len, void* ptr) { DataPointer free_me(data, len); },
+
+
+--- a/src/crypto/crypto_ec.cc
++++ b/src/crypto/crypto_ec.cc
+@@ -207,7 +207,7 @@ void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
+     // NOTE: field_size is in bits
+     int field_size = EC_GROUP_get_degree(ecdh->group_);
+     size_t out_len = (field_size + 7) / 8;
+-    bs = ArrayBuffer::NewBackingStore(env->isolate(), out_len);
++    bs = node::Buffer::CreateBackingStore(env->isolate(), nullptr, out_len, nullptr, nullptr);
+   }
+ 
+   if (!ECDH_compute_key(
+@@ -260,8 +260,7 @@ void ECDH::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
+   std::unique_ptr<BackingStore> bs;
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    bs = ArrayBuffer::NewBackingStore(env->isolate(),
+-                                      BignumPointer::GetByteCount(b));
++    bs = node::Buffer::CreateBackingStore(env->isolate(), nullptr, BignumPointer::GetByteCount(b), nullptr, nullptr);
+   }
+   CHECK_EQ(bs->ByteLength(),
+            BignumPointer::EncodePaddedInto(
+
+
+--- a/src/node_blob.cc
++++ b/src/node_blob.cc
+@@ -12,6 +12,7 @@
+ #include "permission/permission.h"
+ #include "util.h"
+ #include "v8.h"
++#include "node_buffer.h"
+ 
+ #include <algorithm>
+ 
+@@ -81,7 +82,7 @@ void Concat(const FunctionCallbackInfo<Value>& args) {
+   }
+ 
+   std::shared_ptr<BackingStore> store =
+-      ArrayBuffer::NewBackingStore(env->isolate(), total);
++      node::Buffer::CreateBackingStore(env->isolate(), nullptr, total, nullptr, nullptr);
+   uint8_t* ptr = static_cast<uint8_t*>(store->Data());
+   for (size_t n = 0; n < views.size(); n++) {
+     uint8_t* from =
+@@ -209,7 +210,7 @@ void Blob::New(const FunctionCallbackInfo<Value>& args) {
+ 
+       // If the ArrayBuffer is not detachable, we will copy from it instead.
+       std::shared_ptr<BackingStore> store =
+-          ArrayBuffer::NewBackingStore(isolate, byte_length);
++          node::Buffer::CreateBackingStore(isolate, nullptr, byte_length, nullptr, nullptr);
+       uint8_t* ptr = static_cast<uint8_t*>(buf->Data()) + byte_offset;
+       std::copy(ptr, ptr + byte_length, static_cast<uint8_t*>(store->Data()));
+       return DataQueue::CreateInMemoryEntryFromBackingStore(
+@@ -370,7 +371,7 @@ void Blob::Reader::Pull(const FunctionCallbackInfo<Value>& args) {
+       for (size_t n = 0; n < count; n++) total += vecs[n].len;
+ 
+       std::shared_ptr<BackingStore> store =
+-          v8::ArrayBuffer::NewBackingStore(env->isolate(), total);
++          node::Buffer::CreateBackingStore(env->isolate(), nullptr, total, nullptr, nullptr);
+       auto ptr = static_cast<uint8_t*>(store->Data());
+       for (size_t n = 0; n < count; n++) {
+         std::copy(vecs[n].base, vecs[n].base + vecs[n].len, ptr);
+
+
+--- a/src/node_buffer.h
++++ b/src/node_buffer.h
+@@ -86,6 +86,13 @@ static inline bool IsWithinBounds(size_t off, size_t len, size_t max) {
+   return true;
+ }
+ 
++std::unique_ptr<v8::BackingStore> CreateBackingStore(
++    v8::Isolate* isolate,
++    void* data,
++    size_t byte_length,
++    v8::BackingStore::DeleterCallback deleter,
++    void* deleter_data);
++
+ }  // namespace Buffer
+ }  // namespace node
+
+
+--- a/src/node_http2.cc
++++ b/src/node_http2.cc
+@@ -295,7 +295,7 @@ Local<Value> Http2Settings::Pack(
+   std::unique_ptr<BackingStore> bs;
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    bs = ArrayBuffer::NewBackingStore(env->isolate(), count * 6);
++    bs = node::Buffer::CreateBackingStore(env->isolate(), nullptr, count * 6, nullptr, nullptr);
+   }
+   if (nghttp2_pack_settings_payload(static_cast<uint8_t*>(bs->Data()),
+                                     bs->ByteLength(),
+@@ -459,10 +459,10 @@ Origins::Origins(
+ 
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    bs_ = ArrayBuffer::NewBackingStore(env->isolate(),
++    bs_ = node::Buffer::CreateBackingStore(env->isolate(), nullptr,
+                                        alignof(nghttp2_origin_entry) - 1 +
+                                        count_ * sizeof(nghttp2_origin_entry) +
+-                                       origin_string_len);
++                                       origin_string_len, nullptr, nullptr);
+   }
+ 
+   // Make sure the start address is aligned appropriately for an nghttp2_nv*.
+@@ -2080,7 +2080,7 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf_) {
+       [[likely]] {
+     // Shrink to the actual amount of used data.
+     std::unique_ptr<BackingStore> old_bs = std::move(bs);
+-    bs = ArrayBuffer::NewBackingStore(env()->isolate(), nread);
++    bs = node::Buffer::CreateBackingStore(env()->isolate(), nullptr, nread, nullptr, nullptr);
+     memcpy(static_cast<char*>(bs->Data()),
+            static_cast<char*>(old_bs->Data()),
+            nread);
+@@ -2093,8 +2093,7 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf_) {
+     std::unique_ptr<BackingStore> new_bs;
+     {
+       NoArrayBufferZeroFillScope no_zero_fill_scope(env()->isolate_data());
+-      new_bs = ArrayBuffer::NewBackingStore(env()->isolate(),
+-                                            pending_len + nread);
++      new_bs = node::Buffer::CreateBackingStore(env()->isolate(), nullptr, pending_len + nread, nullptr, nullptr);
+     }
+     memcpy(static_cast<char*>(new_bs->Data()),
+            stream_buf_.base + stream_buf_offset_,
+
+
+--- a/src/node_sea.cc
++++ b/src/node_sea.cc
+@@ -12,6 +12,7 @@
+ #include "node_union_bytes.h"
+ #include "node_v8_platform-inl.h"
+ #include "util-inl.h"
++#include "node_buffer.h"
+ 
+ // The POSTJECT_SENTINEL_FUSE macro is a string of random characters selected by
+ // the Node.js project that is present only once in the entire binary. It is
+@@ -592,7 +593,8 @@ void GetAsset(const FunctionCallbackInfo<Value>& args) {
+   }
+   // We cast away the constness here, the JS land should ensure that
+   // the data is not mutated.
+-  std::unique_ptr<v8::BackingStore> store = ArrayBuffer::NewBackingStore(
++  std::unique_ptr<BackingStore> store = node::Buffer::CreateBackingStore(
++      args.GetIsolate(),
+       const_cast<char*>(it->second.data()),
+       it->second.size(),
+       [](void*, size_t, void*) {},
+
+
+--- a/src/node_sqlite.cc
++++ b/src/node_sqlite.cc
+@@ -9,6 +9,7 @@
+ #include "node_mem-inl.h"
+ #include "sqlite3.h"
+ #include "util-inl.h"
++#include "node_buffer.h"
+ 
+ #include <cinttypes>
+ 
+@@ -181,7 +182,7 @@ class UserDefinedFunction {
+           size_t size = static_cast<size_t>(sqlite3_value_bytes(value));
+           auto data =
+               reinterpret_cast<const uint8_t*>(sqlite3_value_blob(value));
+-          auto store = ArrayBuffer::NewBackingStore(isolate, size);
++          auto store = node::Buffer::CreateBackingStore(isolate, nullptr, size, nullptr, nullptr);
+           memcpy(store->Data(), data, size);
+           auto ab = ArrayBuffer::New(isolate, std::move(store));
+           js_val = Uint8Array::New(ab, 0, size);
+@@ -1122,7 +1123,7 @@ MaybeLocal<Value> StatementSync::ColumnToValue(const int column) {
+           static_cast<size_t>(sqlite3_column_bytes(statement_, column));
+       auto data = reinterpret_cast<const uint8_t*>(
+           sqlite3_column_blob(statement_, column));
+-      auto store = ArrayBuffer::NewBackingStore(env()->isolate(), size);
++      auto store = node::Buffer::CreateBackingStore(env()->isolate(), nullptr, size, nullptr, nullptr);
+       memcpy(store->Data(), data, size);
+       auto ab = ArrayBuffer::New(env()->isolate(), std::move(store));
+       return Uint8Array::New(ab, 0, size);
+
+
+--- a/src/node_trace_events.cc
++++ b/src/node_trace_events.cc
+@@ -4,6 +4,7 @@
+ #include "node.h"
+ #include "node_external_reference.h"
+ #include "node_internals.h"
++#include "node_buffer.h"
+ #include "node_v8_platform-inl.h"
+ #include "tracing/agent.h"
+ #include "util-inl.h"
+@@ -133,7 +134,8 @@ static void GetCategoryEnabledBuffer(const FunctionCallbackInfo<Value>& args) {
+       TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(category_name.out());
+   uint8_t* enabled_pointer_cast = const_cast<uint8_t*>(enabled_pointer);
+ 
+-  std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
++  std::unique_ptr<BackingStore> bs = node::Buffer::CreateBackingStore(
++      isolate,
+       enabled_pointer_cast,
+       sizeof(*enabled_pointer_cast),
+       [](void*, size_t, void*) {},
+
+
+--- a/src/quic/session.cc
++++ b/src/quic/session.cc
+@@ -31,6 +31,7 @@
+ #include "streams.h"
+ #include "tlscontext.h"
+ #include "transportparams.h"
++#include "node_buffer.h"
+ 
+ namespace node {
+ 
+@@ -1401,7 +1402,7 @@ void Session::DatagramReceived(const uint8_t* data,
+   // we just drop it on the floor.
+   if (state_->datagram == 0 || datalen == 0) return;
+ 
+-  auto backing = ArrayBuffer::NewBackingStore(env()->isolate(), datalen);
++  auto backing = node::Buffer::CreateBackingStore(env()->isolate(), nullptr, datalen, nullptr, nullptr);
+   Debug(this, "Session is receiving datagram of size %zu", datalen);
+   memcpy(backing->Data(), data, datalen);
+   STAT_INCREMENT(Stats, datagrams_received);
+
+
+--- a/src/quic/streams.cc
++++ b/src/quic/streams.cc
+@@ -12,6 +12,7 @@
+ #include "bindingdata.h"
+ #include "defs.h"
+ #include "session.h"
++#include "node_buffer.h"
+ 
+ namespace node {
+ 
+@@ -959,7 +960,7 @@ void Stream::ReceiveData(const uint8_t* data,
+   }
+ 
+   STAT_INCREMENT_N(Stats, bytes_received, len);
+-  auto backing = ArrayBuffer::NewBackingStore(env()->isolate(), len);
++  auto backing = node::Buffer::CreateBackingStore(env()->isolate(), nullptr, len, nullptr, nullptr);
+   memcpy(backing->Data(), data, len);
+   inbound_->append(DataQueue::CreateInMemoryEntryFromBackingStore(
+       std::move(backing), 0, len));
+
+
+--- a/src/quic/tlscontext.cc
++++ b/src/quic/tlscontext.cc
+@@ -17,6 +17,7 @@
+ #include "defs.h"
+ #include "session.h"
+ #include "transportparams.h"
++#include "node_buffer.h"
+ 
+ namespace node {
+ 
+@@ -218,7 +219,7 @@ int TLSContext::OnNewSession(SSL* ssl, SSL_SESSION* sess) {
+     // and continue without emitting the sessionticket event.
+     if (size > 0 && size <= crypto::SecureContext::kMaxSessionSize) {
+       auto ticket =
+-          ArrayBuffer::NewBackingStore(session.env()->isolate(), size);
++          node::Buffer::CreateBackingStore(session.env()->isolate(), nullptr, size, nullptr, nullptr);
+       auto data = reinterpret_cast<unsigned char*>(ticket->Data());
+       if (i2d_SSL_SESSION(sess, &data) > 0) {
+         session.EmitSessionTicket(Store(std::move(ticket), size));
+
+
+--- a/src/quic/transportparams.cc
++++ b/src/quic/transportparams.cc
+@@ -11,6 +11,7 @@
+ #include "endpoint.h"
+ #include "session.h"
+ #include "tokens.h"
++#include "node_buffer.h"
+ 
+ namespace node {
+ 
+@@ -191,7 +192,7 @@ Store TransportParams::Encode(Environment* env, int version) {
+ 
+   DCHECK_GT(size, 0);
+ 
+-  auto result = ArrayBuffer::NewBackingStore(env->isolate(), size);
++  auto result = node::Buffer::CreateBackingStore(env->isolate(), nullptr, size, nullptr, nullptr);
+ 
+   auto ret = ngtcp2_transport_params_encode_versioned(
+       static_cast<uint8_t*>(result->Data()), size, version, &params_);
+
+
+--- a/src/udp_wrap.cc
++++ b/src/udp_wrap.cc
+@@ -755,11 +755,11 @@ void UDPWrap::OnRecv(ssize_t nread,
+     MakeCallback(env->onmessage_string(), arraysize(argv), argv);
+     return;
+   } else if (nread == 0) {
+-    bs = ArrayBuffer::NewBackingStore(isolate, 0);
++    bs = node::Buffer::CreateBackingStore(isolate, nullptr, 0, nullptr, nullptr);
+   } else if (static_cast<size_t>(nread) != bs->ByteLength()) {
+     CHECK_LE(static_cast<size_t>(nread), bs->ByteLength());
+     std::unique_ptr<BackingStore> old_bs = std::move(bs);
+-    bs = ArrayBuffer::NewBackingStore(isolate, nread);
++    bs = node::Buffer::CreateBackingStore(isolate, nullptr, nread, nullptr, nullptr);
+     memcpy(static_cast<char*>(bs->Data()),
+            static_cast<char*>(old_bs->Data()),
+            nread);
+
+
+--- a/src/crypto/crypto_random.cc
++++ b/src/crypto/crypto_random.cc
+@@ -6,6 +6,7 @@
+ #include "ncrypto.h"
+ #include "threadpoolwork-inl.h"
+ #include "v8.h"
++#include "node_buffer.h"
+ 
+ #include <compare>
+ 
+@@ -79,7 +80,7 @@ MaybeLocal<Value> RandomPrimeTraits::EncodeOutput(
+     Environment* env, const RandomPrimeConfig& params, ByteSource* unused) {
+   size_t size = params.prime.byteLength();
+   std::shared_ptr<BackingStore> store =
+-      ArrayBuffer::NewBackingStore(env->isolate(), size);
++      node::Buffer::CreateBackingStore(env->isolate(), nullptr, size, nullptr, nullptr);
+   CHECK_EQ(size,
+            BignumPointer::EncodePaddedInto(
+                params.prime.get(),
+
+
+--- a/src/crypto/crypto_rsa.cc
++++ b/src/crypto/crypto_rsa.cc
+@@ -8,6 +8,7 @@
+ #include "memory_tracker-inl.h"
+ #include "threadpoolwork-inl.h"
+ #include "v8.h"
++#include "node_buffer.h"
+ 
+ #include <openssl/bn.h>
+ #include <openssl/rsa.h>
+@@ -538,8 +539,8 @@ Maybe<void> GetRsaKeyDetail(Environment* env,
+   std::unique_ptr<BackingStore> public_exponent;
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    public_exponent = ArrayBuffer::NewBackingStore(
+-        env->isolate(), BignumPointer::GetByteCount(e));
++    public_exponent = node::Buffer::CreateBackingStore(
++        env->isolate(), nullptr, BignumPointer::GetByteCount(e), nullptr, nullptr);
+   }
+   CHECK_EQ(BignumPointer::EncodePaddedInto(
+                e,
+
+
+--- a/src/crypto/crypto_sig.cc
++++ b/src/crypto/crypto_sig.cc
+@@ -9,6 +9,7 @@
+ #include "openssl/ec.h"
+ #include "threadpoolwork-inl.h"
+ #include "v8.h"
++#include "node_buffer.h"
+ 
+ namespace node {
+ 
+@@ -95,7 +96,7 @@ std::unique_ptr<BackingStore> Node_SignFinal(Environment* env,
+   std::unique_ptr<BackingStore> sig;
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    sig = ArrayBuffer::NewBackingStore(env->isolate(), sig_len);
++    sig = node::Buffer::CreateBackingStore(env->isolate(), nullptr, sig_len, nullptr, nullptr);
+   }
+   EVPKeyCtxPointer pkctx = pkey.newCtx();
+   if (pkctx && EVP_PKEY_sign_init(pkctx.get()) > 0 &&
+@@ -109,10 +110,10 @@ std::unique_ptr<BackingStore> Node_SignFinal(Environment* env,
+                     m_len) > 0) {
+     CHECK_LE(sig_len, sig->ByteLength());
+     if (sig_len == 0) {
+-      sig = ArrayBuffer::NewBackingStore(env->isolate(), 0);
++      sig = node::Buffer::CreateBackingStore(env->isolate(), nullptr, 0, nullptr, nullptr);
+     } else if (sig_len != sig->ByteLength()) {
+       std::unique_ptr<BackingStore> old_sig = std::move(sig);
+-      sig = ArrayBuffer::NewBackingStore(env->isolate(), sig_len);
++      sig = node::Buffer::CreateBackingStore(env->isolate(), nullptr, sig_len, nullptr, nullptr);
+       memcpy(static_cast<char*>(sig->Data()),
+              static_cast<char*>(old_sig->Data()),
+              sig_len);
+@@ -173,7 +174,7 @@ std::unique_ptr<BackingStore> ConvertSignatureToP1363(
+   std::unique_ptr<BackingStore> buf;
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    buf = ArrayBuffer::NewBackingStore(env->isolate(), 2 * n);
++    buf = node::Buffer::CreateBackingStore(env->isolate(), nullptr, 2 * n, nullptr, nullptr);
+   }
+   if (!ExtractP1363(static_cast<unsigned char*>(signature->Data()),
+                     static_cast<unsigned char*>(buf->Data()),
+
+
+--- a/src/crypto/crypto_tls.cc
++++ b/src/crypto/crypto_tls.cc
+@@ -1089,7 +1089,7 @@ int TLSWrap::DoWrite(WriteWrap* w,
+   if (nonempty_count != 1) {
+     {
+       NoArrayBufferZeroFillScope no_zero_fill_scope(env()->isolate_data());
+-      bs = ArrayBuffer::NewBackingStore(env()->isolate(), length);
++      bs = node::Buffer::CreateBackingStore(env()->isolate(), nullptr, length, nullptr, nullptr);
+     }
+     size_t offset = 0;
+     for (i = 0; i < count; i++) {
+@@ -1108,7 +1108,7 @@ int TLSWrap::DoWrite(WriteWrap* w,
+ 
+     if (written == -1) {
+       NoArrayBufferZeroFillScope no_zero_fill_scope(env()->isolate_data());
+-      bs = ArrayBuffer::NewBackingStore(env()->isolate(), length);
++      bs = node::Buffer::CreateBackingStore(env()->isolate(), nullptr, length, nullptr, nullptr);
+       memcpy(bs->Data(), buf->base, buf->len);
+     }
+   }
+@@ -1753,7 +1753,7 @@ void TLSWrap::GetFinished(const FunctionCallbackInfo<Value>& args) {
+   std::unique_ptr<BackingStore> bs;
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    bs = ArrayBuffer::NewBackingStore(env->isolate(), len);
++    bs = node::Buffer::CreateBackingStore(env->isolate(), nullptr, len, nullptr, nullptr);
+   }
+ 
+   CHECK_EQ(bs->ByteLength(),
+@@ -1784,7 +1784,7 @@ void TLSWrap::GetPeerFinished(const FunctionCallbackInfo<Value>& args) {
+   std::unique_ptr<BackingStore> bs;
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    bs = ArrayBuffer::NewBackingStore(env->isolate(), len);
++    bs = node::Buffer::CreateBackingStore(env->isolate(), nullptr, len, nullptr, nullptr);
+   }
+ 
+   CHECK_EQ(bs->ByteLength(),
+@@ -1813,7 +1813,7 @@ void TLSWrap::GetSession(const FunctionCallbackInfo<Value>& args) {
+   std::unique_ptr<BackingStore> bs;
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    bs = ArrayBuffer::NewBackingStore(env->isolate(), slen);
++    bs = node::Buffer::CreateBackingStore(env->isolate(), nullptr, slen, nullptr, nullptr);
+   }
+ 
+   unsigned char* p = static_cast<unsigned char*>(bs->Data());
+@@ -2000,7 +2000,7 @@ void TLSWrap::ExportKeyingMaterial(const FunctionCallbackInfo<Value>& args) {
+   std::unique_ptr<BackingStore> bs;
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    bs = ArrayBuffer::NewBackingStore(env->isolate(), olen);
++    bs = node::Buffer::CreateBackingStore(env->isolate(), nullptr, olen, nullptr, nullptr);
+   }
+ 
+   ByteSource context;
+
+
+--- a/src/crypto/crypto_util.cc
++++ b/src/crypto/crypto_util.cc
+@@ -333,11 +333,12 @@ ByteSource& ByteSource::operator=(ByteSource&& other) noexcept {
+   return *this;
+ }
+ 
+-std::unique_ptr<BackingStore> ByteSource::ReleaseToBackingStore() {
++std::unique_ptr<BackingStore> ByteSource::ReleaseToBackingStore(Environment* env) {
+   // It's ok for allocated_data_ to be nullptr but
+   // only if size_ is zero.
+   CHECK_IMPLIES(size_ > 0, allocated_data_ != nullptr);
+-  std::unique_ptr<BackingStore> ptr = ArrayBuffer::NewBackingStore(
++  std::unique_ptr<BackingStore> ptr = node::Buffer::CreateBackingStore(
++      env->isolate(),
+       allocated_data_,
+       size(),
+       [](void* data, size_t length, void* deleter_data) {
+@@ -351,7 +352,7 @@ std::unique_ptr<BackingStore> ByteSource::ReleaseToBackingStore() {
+ }
+ 
+ Local<ArrayBuffer> ByteSource::ToArrayBuffer(Environment* env) {
+-  std::unique_ptr<BackingStore> store = ReleaseToBackingStore();
++  std::unique_ptr<BackingStore> store = ReleaseToBackingStore(env);
+   return ArrayBuffer::New(env->isolate(), std::move(store));
+ }
+ 
+@@ -668,7 +669,8 @@ void SecureBuffer(const FunctionCallbackInfo<Value>& args) {
+     return;
+   }
+   std::shared_ptr<BackingStore> store =
+-      ArrayBuffer::NewBackingStore(
++      node::Buffer::CreateBackingStore(
++          env->isolate(),
+           data,
+           len,
+           [](void* data, size_t len, void* deleter_data) {
+
+
+--- a/src/crypto/crypto_util.h
++++ b/src/crypto/crypto_util.h
+@@ -241,7 +241,7 @@ class ByteSource {
+   // Creates a v8::BackingStore that takes over responsibility for
+   // any allocated data. The ByteSource will be reset with size = 0
+   // after being called.
+-  std::unique_ptr<v8::BackingStore> ReleaseToBackingStore();
++  std::unique_ptr<v8::BackingStore> ReleaseToBackingStore(Environment* env);
+ 
+   v8::Local<v8::ArrayBuffer> ToArrayBuffer(Environment* env);
+
+
+--- a/src/crypto/crypto_x509.cc
++++ b/src/crypto/crypto_x509.cc
+@@ -9,6 +9,7 @@
+ #include "node_errors.h"
+ #include "util-inl.h"
+ #include "v8.h"
++#include "node_buffer.h"
+ 
+ #include <string>
+ #include <vector>
+@@ -167,7 +168,8 @@ MaybeLocal<Value> ToV8Value(Local<Context> context, const BIOPointer& bio) {
+ MaybeLocal<Value> ToBuffer(Environment* env, BIOPointer* bio) {
+   if (bio == nullptr || !*bio) return {};
+   BUF_MEM* mem = *bio;
+-  auto backing = ArrayBuffer::NewBackingStore(
++  auto backing = node::Buffer::CreateBackingStore(
++      env->isolate(),
+       mem->data,
+       mem->length,
+       [](void*, size_t, void* data) {
+@@ -671,7 +673,7 @@ MaybeLocal<Object> GetPubKey(Environment* env, OSSL3_CONST RSA* rsa) {
+   std::unique_ptr<BackingStore> bs;
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    bs = ArrayBuffer::NewBackingStore(env->isolate(), size);
++    bs = node::Buffer::CreateBackingStore(env->isolate(), nullptr, size, nullptr, nullptr);
+   }
+ 
+   unsigned char* serialized = reinterpret_cast<unsigned char*>(bs->Data());
+
+
+--- a/src/encoding_binding.cc
++++ b/src/encoding_binding.cc
+@@ -4,6 +4,7 @@
+ #include "node_buffer.h"
+ #include "node_errors.h"
+ #include "node_external_reference.h"
++#include "node_buffer.h"
+ #include "simdutf.h"
+ #include "string_bytes.h"
+ #include "v8.h"
+@@ -126,7 +127,7 @@ void BindingData::EncodeUtf8String(const FunctionCallbackInfo<Value>& args) {
+   {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+     std::unique_ptr<BackingStore> bs =
+-        ArrayBuffer::NewBackingStore(isolate, length);
++        node::Buffer::CreateBackingStore(isolate, nullptr, length, nullptr, nullptr);
+ 
+     CHECK(bs);
+
+
+--- a/src/env.cc
++++ b/src/env.cc
+@@ -750,7 +750,7 @@ void Environment::add_refs(int64_t diff) {
+ uv_buf_t Environment::allocate_managed_buffer(const size_t suggested_size) {
+   NoArrayBufferZeroFillScope no_zero_fill_scope(isolate_data());
+   std::unique_ptr<v8::BackingStore> bs =
+-      v8::ArrayBuffer::NewBackingStore(isolate(), suggested_size);
++      node::Buffer::CreateBackingStore(isolate(), nullptr, suggested_size, nullptr, nullptr);
+   uv_buf_t buf = uv_buf_init(static_cast<char*>(bs->Data()), bs->ByteLength());
+   released_allocated_buffers_.emplace(buf.base, std::move(bs));
+   return buf;
+
+
+--- a/src/stream_base.cc
++++ b/src/stream_base.cc
+@@ -244,7 +244,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
+   std::unique_ptr<BackingStore> bs;
+   if (storage_size > 0) {
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    bs = ArrayBuffer::NewBackingStore(isolate, storage_size);
++    bs = node::Buffer::CreateBackingStore(isolate, nullptr, storage_size, nullptr, nullptr);
+   }
+ 
+   offset = 0;
+@@ -399,13 +399,13 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
+   if (try_write) {
+     // Copy partial data
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    bs = ArrayBuffer::NewBackingStore(isolate, buf.len);
++    bs = node::Buffer::CreateBackingStore(isolate, nullptr, buf.len, nullptr, nullptr);
+     memcpy(static_cast<char*>(bs->Data()), buf.base, buf.len);
+     data_size = buf.len;
+   } else {
+     // Write it
+     NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+-    bs = ArrayBuffer::NewBackingStore(isolate, storage_size);
++      bs = node::Buffer::CreateBackingStore(isolate, nullptr, storage_size, nullptr, nullptr);
+     data_size = StringBytes::Write(isolate,
+                                    static_cast<char*>(bs->Data()),
+                                    storage_size,
+@@ -707,7 +707,7 @@ void EmitToJSStreamListener::OnStreamRead(ssize_t nread, const uv_buf_t& buf_) {
+   CHECK_LE(static_cast<size_t>(nread), bs->ByteLength());
+   if (static_cast<size_t>(nread) != bs->ByteLength()) {
+     std::unique_ptr<BackingStore> old_bs = std::move(bs);
+-    bs = ArrayBuffer::NewBackingStore(isolate, nread);
++    bs = node::Buffer::CreateBackingStore(isolate, nullptr, nread, nullptr, nullptr);
+     memcpy(static_cast<char*>(bs->Data()),
+            static_cast<char*>(old_bs->Data()),
+            nread);
+

--- a/src/patch/22.14.0/v8config.patch
+++ b/src/patch/22.14.0/v8config.patch
@@ -1,5 +1,5 @@
---- deps/v8/include/v8config.h
-+++ deps/v8/include/v8config.h
+--- a/deps/v8/include/v8config.h
++++ b/deps/v8/include/v8config.h
 @@ -491,8 +491,9 @@
  # define V8_ASSUME USE
  #endif

--- a/src/patch/22.14.0/v8config.patch
+++ b/src/patch/22.14.0/v8config.patch
@@ -1,0 +1,14 @@
+--- deps/v8/include/v8config.h
++++ deps/v8/include/v8config.h
+@@ -491,8 +491,9 @@
+ # define V8_ASSUME USE
+ #endif
+ 
+-// Prefer c++20 std::assume_aligned
+-#if __cplusplus >= 202002L && defined(__cpp_lib_assume_aligned)
++// Prefer c++20 std::assume_aligned. Don't use it on MSVC though, because it's
++// not happy with our large 4GB alignment values.
++#if __cplusplus >= 202002L && defined(__cpp_lib_assume_aligned) && !V8_CC_MSVC
+ # define V8_ASSUME_ALIGNED(ptr, alignment) \
+   std::assume_aligned<(alignment)>(ptr)
+ #elif V8_HAS_BUILTIN_ASSUME_ALIGNED

--- a/src/patch/22.14.0/vcbuild.bat.patch
+++ b/src/patch/22.14.0/vcbuild.bat.patch
@@ -1,8 +1,8 @@
 expose option for configuring pointer compression
 
 
---- vcbuild.bat
-+++ vcbuild.bat
+--- a/vcbuild.bat
++++ b/vcbuild.bat
 @@ -72,6 +72,7 @@ set doc=
  set extra_msbuild_args=
  set compile_commands=

--- a/src/patch/22.14.0/vcbuild.bat.patch
+++ b/src/patch/22.14.0/vcbuild.bat.patch
@@ -1,0 +1,28 @@
+expose option for configuring pointer compression
+
+
+--- vcbuild.bat
++++ vcbuild.bat
+@@ -72,6 +72,7 @@ set doc=
+ set extra_msbuild_args=
+ set compile_commands=
+ set exit_code=0
++set v8_ptr_compress=
+ 
+ :next-arg
+ if "%1"=="" goto args-done
+@@ -146,6 +147,7 @@ if /i "%1"=="cctest"        set cctest=1&goto arg-ok
+ if /i "%1"=="openssl-no-asm"   set openssl_no_asm=1&goto arg-ok
+ if /i "%1"=="no-shared-roheap" set no_shared_roheap=1&goto arg-ok
+ if /i "%1"=="doc"           set doc=1&goto arg-ok
++if /i "%1"=="v8_ptr_compress"   set v8_ptr_compress=1&goto arg-ok
+ if /i "%1"=="binlog"        set extra_msbuild_args=/binaryLogger:out\%config%\node.binlog&goto arg-ok
+ if /i "%1"=="compile-commands" set compile_commands=1&goto arg-ok
+ 
+@@ -206,6 +208,7 @@ if defined debug_nghttp2    set configure_flags=%configure_flags% --debug-nghttp
+ if defined openssl_no_asm   set configure_flags=%configure_flags% --openssl-no-asm
+ if defined no_shared_roheap set configure_flags=%configure_flags% --disable-shared-readonly-heap
+ if defined DEBUG_HELPER     set configure_flags=%configure_flags% --verbose
++if defined v8_ptr_compress  set configure_flags=%configure_flags% --experimental-enable-pointer-compression
+ if defined compile_commands set configure_flags=%configure_flags% -C
+ if "%target_arch%"=="x86" if "%PROCESSOR_ARCHITECTURE%"=="AMD64" set configure_flags=%configure_flags% --no-cross-compiling

--- a/src/util.js
+++ b/src/util.js
@@ -79,16 +79,17 @@ function runCommand(command, args = [], cwd = undefined, env = undefined, verbos
   });
 }
 
-async function patchFile(file, patchFile) {
-  if(!fs.existsSync(patchFile)) return; // noop
+async function patchFile(baseDir, patchFile) {
+  if (!fs.existsSync(patchFile)) return; // noop
   await new Promise((resolve, reject) => {
     const proc = spawn(
       'patch',
       [
-        '-uN',
-        file
+        '-uN', // Unified patch format
+        '-p1' // Adjust the file path by stripping leading directories (a/ and b/)
       ],
       {
+        cwd: baseDir, // Apply the patches in the provided directory
         stdio: [
           null,
           'inherit',


### PR DESCRIPTION
List of changes:
- Updated the docker image builders to install Python 3.9 needed for installing nodejs 22
- Bumped docker image builders version
- Disabled Azure pipeline for building the artifact for Linux with pointer compression (we don't use it anywhere)
- Disabled Azure pipeline for building the artifact for Windows (now we have Jenkins job for it https://jenkins.build.cribl.io/job/cribl-stream/job/js2bin/)
- Fixed the bug preventing building the artifact for Linux with pointer compression
- Patch `configure.py.patch` was updated
- New patches `v8config.patch`, `features.gypi.patch`, `node_buffer.cc.patch`, and `v8_backing_store_callers.patch` are added, where `v8_backing_store_callers.patch` itself contains 26 patches
- Patches include the changes required for fixing the memory leak in upstream when pointer compression is enabled