### PR TITLE
optimized eos

### DIFF
--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -239,9 +239,14 @@ class NodeJsBuilder {
     }
   }
 
+  async patchNodePerformance() {
+    await patchFile(this.nodeSrcDir, join(this.patchDir, 'end-of-stream.js.patch'));
+  }
+
   async applyPatches() {
     await this.patchThirdPartyMain();
     await this.patchNodeCompileIssues();
+    await this.patchNodePerformance();
   }
 
   printDiskUsage() {

--- a/src/patch/22.17.1/end-of-stream.js.patch
+++ b/src/patch/22.17.1/end-of-stream.js.patch
@@ -1,0 +1,37 @@
+--- a/lib/internal/streams/end-of-stream.js
++++ b/lib/internal/streams/end-of-stream.js
+@@ -44,6 +44,8 @@ const {
+   kIsClosedPromise,
+ } = require('internal/streams/utils');
+ 
++const { getHookArrays } = require('internal/async_hooks');
++
+ // Lazy load
+ let AsyncLocalStorage;
+ let addAbortListener;
+@@ -65,9 +67,22 @@ function eos(stream, options, callback) {
+   }
+   validateFunction(callback, 'callback');
+   validateAbortSignal(options.signal, 'options.signal');
+-
+-  AsyncLocalStorage ??= require('async_hooks').AsyncLocalStorage;
+-  callback = once(AsyncLocalStorage.bind(callback));
++  
++  // Check if async hooks are enabled by checking if there are any active hooks
++  const [activeHooks] = getHookArrays();
++  const hasActiveHooks = activeHooks.length > 0;
++
++  // Performance optimization: only apply AsyncLocalStorage binding if async hooks are actually active
++  // This avoids the performance cost of creating AsyncResource instances and setting up
++  // async context tracking when no user-defined async hooks are active
++  if (hasActiveHooks) {
++    // Async hooks are active, preserve async context by binding callback to AsyncLocalStorage
++    AsyncLocalStorage ??= require('async_hooks').AsyncLocalStorage;
++    callback = once(AsyncLocalStorage.bind(callback));
++  } else {
++    // No async hooks active, use regular once wrapper without AsyncResource overhead
++    callback = once(callback);
++  }
+ 
+   if (isReadableStream(stream) || isWritableStream(stream)) {
+     return eosWeb(stream, options, callback);


### PR DESCRIPTION
This PR optimizes the performance of eos function, which affects any application that uses it in the hot path. The [commit](https://github.com/nodejs/node/pull/57865/files#diff-f355a772a51133f54ef288a365ec05a70b9f3f2e0a2f46f5ba2612e31a62f810) in the upstream in nodejs 22.16.0 caused this issue.
Using my JS [benchmark](https://github.com/avcribl/process_memory/blob/master/benchmark_js/benchmark_data_processing_eos.js) and with this patch we get:
```
============================================================
Data Processing Performance Test: 100,000 stream operations
============================================================
Starting data processing performance tests...

Progress: 0/100 batches completed
Progress: 10/100 batches completed
Progress: 20/100 batches completed
Progress: 30/100 batches completed
Progress: 40/100 batches completed
Progress: 50/100 batches completed
Progress: 60/100 batches completed
Progress: 70/100 batches completed
Progress: 80/100 batches completed
Progress: 90/100 batches completed
Duration: 2.06s
Throughput: 48,625.431 operations/sec
Benchmark completed!
```

Without using this patch we get:
```
============================================================
Data Processing Performance Test: 100,000 stream operations
============================================================
Starting data processing performance tests...

Progress: 0/100 batches completed
Progress: 10/100 batches completed
Progress: 20/100 batches completed
Progress: 30/100 batches completed
Progress: 40/100 batches completed
Progress: 50/100 batches completed
Progress: 60/100 batches completed
Progress: 70/100 batches completed
Progress: 80/100 batches completed
Progress: 90/100 batches completed
Duration: 6.95s
Throughput: 14,391.015 operations/sec
Benchmark completed!
```