### PR TITLE
changed compression algo to brotli

### DIFF
--- a/src/_third_party_main.js
+++ b/src/_third_party_main.js
@@ -1,6 +1,6 @@
 
 const Module = require('module');
-const { gunzipSync } = require('zlib');
+const { brotliDecompressSync } = require('zlib');
 const { join, dirname } = require('path');
 
 let source = process.binding('natives')._js2bin_app_main;
@@ -40,6 +40,6 @@ if (cluster.worker) {
   process.argv.splice(1, 0, __filename); // don't mess with argv in clustering
 }
 
-${gunzipSync(Buffer.from(source, 'base64'), {chunkSize: 128*1024*1024}).toString()}
+${brotliDecompressSync(Buffer.from(source, 'base64'), { chunkSize: 128 * 1024 * 1024 }).toString()}
 
 `, filename);


### PR DESCRIPTION
Changes:
- Changed compression algorithm to brotli
- Added `build-version` cli argument. This is long overdue, enabling us to have different binary versions for a nodejs version (in case if we introduce a new patch or anything like that)
- Added `download-url` cli argument. This is very handy for R&D and testing a new binary before merging the PR. For example, I used it to build a TC and ran perf tests.

Results:
- The brotli compression algo compresses the code to 4213141 vs what it used to be 6241709 with gzip compression algo. It's a 2MB reduction which will give us enough headroom for the future.
- A TC was cut based on the new binary and the perf tests and regression tests were ran and no anomalies were found