### PR TITLE
added patch for fixing tls conn issue

### DIFF
--- a/js2bin.js
+++ b/js2bin.js
@@ -33,6 +33,7 @@ command-args: take the form of --name=value
           e.g. --node=10.16.0
   --size: Amount of preallocated space, can specify more than one. 
           e.g. --size=2MB --size=4MB
+  --commitHash: (opt) Git commit hash to build from. It's useful for building NodeJS from a specific commit hash instead of a versioned release.
   --dir:       (opt) Working directory, if not specified use cwd
   --cache:     (opt) whether to keep build in the cache (to be reused by --build)
   --upload:    (opt) whether to upload node build to github releases
@@ -118,7 +119,7 @@ if (args.build) {
     let lastBuilder;
     sizes.forEach(size => {
       archs.forEach(arch => {
-        const builder = new NodeJsBuilder(args.dir, version, size, undefined, undefined, args.buildVersion);
+        const builder = new NodeJsBuilder(args.dir, version, size, undefined, undefined, args.buildVersion, args.commitHash);
         lastBuilder = builder;
         p = p.then(() => {
           log(`building for version=${version}, size=${size} arch=${arch}`);

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -3,9 +3,12 @@ const { log, download, upload, deleteArtifact, getAssetIdByName, fetch, mkdirp, 
 const { brotliCompressSync, createGunzip } = require('zlib');
 const zlib = require('zlib');
 const { join, dirname, basename, parse, resolve } = require('path');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
 const fs = require('fs');
 const os = require('os');
 const tar = require('tar-fs');
+const execFileAsync = promisify(execFile);
 const pkg = require('../package.json');
 
 const isWindows = process.platform === 'win32';
@@ -48,6 +51,20 @@ function buildName(platform, arch, placeHolderSizeMB, version, buildVersion) {
   return `${platform}-${arch}-${version}-${buildVersion}-${placeHolderSizeMB}MB`;
 }
 
+function commitDirSuffix(commitHash) {
+  const s = String(commitHash).trim().replace(/^[\^#]+/, '');
+  const lower = s.toLowerCase();
+  if (/^[0-9a-f]+$/.test(lower)) {
+    return lower;
+  }
+  return lower.replace(/[^a-z0-9-]/g, '_').slice(0, 64) || 'unknown';
+}
+
+function parseSemverFromDescribe(desc) {
+  const m = String(desc).match(/v?(\d+\.\d+\.\d+)/);
+  return m ? m[1] : null;
+}
+
 class NodeJsBuilder {
   constructor(cwd, version, mainAppFile, appName, patchDir, buildVersion, commitHash) {
     this.version = version;
@@ -70,7 +87,9 @@ class NodeJsBuilder {
     this.patchDir = patchDir || join(this.srcDir, 'patch', version);
     this.buildDir = join(cwd || process.cwd(), 'build');
     this.nodeSrcFile = join(this.buildDir, `node-v${version}.tar.gz`);
-    this.nodeSrcDir = join(this.buildDir, `node-v${version}`);
+    this.nodeSrcDir = commitHash
+      ? join(this.buildDir, `node-git-${commitDirSuffix(commitHash)}`)
+      : join(this.buildDir, `node-v${version}`);
     this.cacheDir = join(cwd || process.cwd(), 'cache');
     this.resultFile = isWindows ? join(this.nodeSrcDir, 'Release', 'node.exe') : join(this.nodeSrcDir, 'out', 'Release', 'node');
     this.placeHolderSizeMB = -1;
@@ -89,10 +108,29 @@ class NodeJsBuilder {
     return arch in prettyArch ? prettyArch[arch] : arch;
   }
 
+  inferVersionAndPatchDirFromGit() {
+    return execFileAsync('git', ['describe', '--tags', '--always'], { cwd: this.nodeSrcDir })
+      .then(({ stdout }) => {
+        const describe = stdout.trim();
+        const semver = parseSemverFromDescribe(describe);
+        if (!semver) {
+          throw new Error(`Could not parse semver from git describe output: ${describe}`);
+        }
+        this.version = semver;
+        this.patchDir = join(this.srcDir, 'patch', this.version);
+        log(`inferred version=${this.version} from git describe (${describe})`);
+      });
+  }
+
   downloadExpandNodeSourceWithCommit() {
+    const afterSourceReady = () =>
+      this.inferVersionAndPatchDirFromGit().then(() =>
+        this.version.split('.')[0] >= 15 ? this.applyPatches() : Promise.resolve()
+      );
+
     if (fs.existsSync(this.nodePath('configure'))) {
-      log(`node version=${this.version} already downloaded and expanded, using it`);
-      return Promise.resolve();
+      log(`node commit=${this.commitHash} already downloaded and expanded, using it`);
+      return afterSourceReady();
     }
     log(`cloning node source for commit=${this.commitHash} ...`);
 
@@ -104,7 +142,7 @@ class NodeJsBuilder {
         log(`checking out commit hash: ${this.commitHash}`);
         return runCommand('git', ['checkout', this.commitHash], this.nodeSrcDir);
       })
-      .then(() => this.version.split('.')[0] >= 15 ? this.applyPatches() : Promise.resolve());
+      .then(() => afterSourceReady());
   }
 
   downloadExpandNodeSource() {

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -49,7 +49,7 @@ function buildName(platform, arch, placeHolderSizeMB, version, buildVersion) {
 }
 
 class NodeJsBuilder {
-  constructor(cwd, version, mainAppFile, appName, patchDir, buildVersion) {
+  constructor(cwd, version, mainAppFile, appName, patchDir, buildVersion, commitHash) {
     this.version = version;
     this.appFile = resolve(mainAppFile);
     this.appName = appName;
@@ -75,6 +75,7 @@ class NodeJsBuilder {
     this.resultFile = isWindows ? join(this.nodeSrcDir, 'Release', 'node.exe') : join(this.nodeSrcDir, 'out', 'Release', 'node');
     this.placeHolderSizeMB = -1;
     this.builderImageVersion = 3;
+    this.commitHash = commitHash;
   }
 
   static platform() {
@@ -86,6 +87,24 @@ class NodeJsBuilder {
       arch = arch.split('/')[1];
     }
     return arch in prettyArch ? prettyArch[arch] : arch;
+  }
+
+  downloadExpandNodeSourceWithCommit() {
+    if (fs.existsSync(this.nodePath('configure'))) {
+      log(`node version=${this.version} already downloaded and expanded, using it`);
+      return Promise.resolve();
+    }
+    log(`cloning node source for commit=${this.commitHash} ...`);
+
+    return mkdirp(this.buildDir)
+      .then(() => {
+        return runCommand('git', ['clone', 'https://github.com/nodejs/node.git', this.nodeSrcDir], this.buildDir);
+      })
+      .then(() => {
+        log(`checking out commit hash: ${this.commitHash}`);
+        return runCommand('git', ['checkout', this.commitHash], this.nodeSrcDir);
+      })
+      .then(() => this.version.split('.')[0] >= 15 ? this.applyPatches() : Promise.resolve());
   }
 
   downloadExpandNodeSource() {
@@ -252,6 +271,7 @@ class NodeJsBuilder {
   async patchNodePerformance() {
     await patchFile(this.nodeSrcDir, join(this.patchDir, 'json-stringifier.cc.patch'));
     await patchFile(this.nodeSrcDir, join(this.patchDir, 'end-of-stream.js.patch'));
+    await patchFile(this.nodeSrcDir, join(this.patchDir, 't1_lib.c.patch'));
   }
 
   async applyPatches() {
@@ -271,26 +291,26 @@ class NodeJsBuilder {
   buildInContainer(ptrCompression) {
     const containerTag = `cribl/js2bin-builder:${this.builderImageVersion}`;
     return runCommand(
-        'docker', ['run',
-          '-v', `${process.cwd()}:/js2bin/`,
-          '-t', containerTag,
-          '/bin/bash', '-c',
-        `source /opt/rh/devtoolset-10/enable && cd /js2bin && npm install && ./js2bin.js --ci --node=${this.version} --size=${this.placeHolderSizeMB}MB ${ptrCompression ? '--pointer-compress=true' : ''}`
-        ]
-      );
+      'docker', ['run',
+        '-v', `${process.cwd()}:/js2bin/`,
+        '-t', containerTag,
+        '/bin/bash', '-c',
+        `source /opt/rh/devtoolset-10/enable && cd /js2bin && npm install && ./js2bin.js --ci --node=${this.version} --size=${this.placeHolderSizeMB}MB ${this.commitHash ? `--commitHash=${this.commitHash}` : ''} ${ptrCompression ? '--pointer-compress=true' : ''}`
+      ]
+    );
   }
 
   buildInContainerNonX64(arch, ptrCompression) {
     const containerTag = `cribl/js2bin-builder:${this.builderImageVersion}-nonx64`;
     return runCommand(
-        'docker', ['run',
-          '--platform', arch,
-          '-v', `${process.cwd()}:/js2bin/`,
-          '-t', containerTag,
-          '/bin/bash', '-c',
-          `source /opt/rh/devtoolset-10/enable && cd /js2bin && npm install && ./js2bin.js --ci --node=${this.version} --size=${this.placeHolderSizeMB}MB ${ptrCompression ? '--pointer-compress=true' : ''}`
-        ]
-      );
+      'docker', ['run',
+        '--platform', arch,
+        '-v', `${process.cwd()}:/js2bin/`,
+        '-t', containerTag,
+        '/bin/bash', '-c',
+          `source /opt/rh/devtoolset-10/enable && cd /js2bin && npm install && ./js2bin.js --ci --node=${this.version} --size=${this.placeHolderSizeMB}MB ${this.commitHash ? `--commitHash=${this.commitHash}` : ''} ${ptrCompression ? '--pointer-compress=true' : ''}`
+      ]
+    );
   }
 
   // 1. download node source
@@ -306,7 +326,7 @@ class NodeJsBuilder {
       else          configArgs.push('--experimental-enable-pointer-compression');
     }
     return this.printDiskUsage()
-      .then(() => this.downloadExpandNodeSource())
+      .then(() => this.commitHash ? this.downloadExpandNodeSourceWithCommit() : this.downloadExpandNodeSource())
       .then(() => this.prepareNodeJsBuild())
       .then(() => {
         if (isWindows) { return runCommand(this.make, makeArgs, this.nodeSrcDir); }

--- a/src/patch/22.22.0/t1_lib.c.patch
+++ b/src/patch/22.22.0/t1_lib.c.patch
@@ -1,0 +1,11 @@
+--- a/deps/openssl/openssl/ssl/t1_lib.c
++++ b/deps/openssl/openssl/ssl/t1_lib.c
+@@ -202,7 +202,7 @@ static const unsigned char ecformats_default[] = {
+ /* Group list string of the built-in pseudo group DEFAULT */
+ #define DEFAULT_GROUP_NAME "DEFAULT"
+ #define TLS_DEFAULT_GROUP_LIST \
+-    "?*X25519MLKEM768 / ?*X25519:?secp256r1 / ?X448:?secp384r1:?secp521r1 / ?ffdhe2048:?ffdhe3072"
++    "?*X25519:?secp256r1 / ?X448:?secp384r1:?secp521r1 / ?ffdhe2048:?ffdhe3072"
+ 
+ static const uint16_t suiteb_curves[] = {
+     OSSL_TLS_GROUP_ID_secp256r1,


### PR DESCRIPTION
There are two changes in this PR:
- Added a patch to remove ML KEM from the tls default group (the main change)
- Added the capability of compiling nodejs from an upstream commit hash (this is only for the sake of R&D and troubleshooting)