### PR TITLE
feat(INFRA-7979): sign windows binary

### DIFF
--- a/js2bin.js
+++ b/js2bin.js
@@ -28,6 +28,11 @@ command-args: take the form of --name=value
               e.g. --build-version=v2
   --download-url: (opt) Custom URL to download pre-built binaries from
                 e.g. --download-url=https://example.com/binaries/
+  --verify-signature: (opt) After downloading the cached binary and before
+                modifying it, run signtool verify /pa on it. Fails the build
+                if the cached binary is unsigned or has an invalid signature.
+                Windows-only (no-op on other platforms). Requires signtool.exe
+                on PATH (Windows SDK).
   --enable-overlay: (opt) Use an overlay-enabled cached binary (built via --ci --enable-overlay).
                     Disabled by default.
   --signing-public-key: Path to ECDSA P-256 public key PEM file to embed into
@@ -97,6 +102,7 @@ function parseArgs() {
   args.ptrCompression = (args['pointer-compress'] == 'true');
   args.buildVersion = (args['build-version'] || 'v1');
   args.downloadUrl = (args['download-url'] || undefined);
+  args.verifySignature = (args['verify-signature'] === true);
   args.enableOverlay = (args['enable-overlay'] === true);
   args.signingPublicKey = (args['signing-public-key'] || undefined);
   if (args.signingPublicKey && !args.enableOverlay) {
@@ -135,7 +141,7 @@ if (args.build) {
         const arch = args.arch || 'x64';
         log(`building for version=${version}, plat=${plat} app=${app}} arch=${arch}`);
         const outName = args.name ? `${args.name}-${plat}-${arch}` : undefined;
-        return builder.buildFromCached(plat, arch, outName, args.cache, args.size, args.downloadUrl);
+        return builder.buildFromCached(plat, arch, outName, args.cache, args.size, args.downloadUrl, args.verifySignature);
       });
     });
   });

--- a/js2bin.js
+++ b/js2bin.js
@@ -53,6 +53,10 @@ command-args: take the form of --name=value
   --dir:       (opt) Working directory, if not specified use cwd
   --cache:     (opt) whether to keep build in the cache (to be reused by --build)
   --upload:    (opt) whether to upload node build to github releases
+  --sign:      (opt) Authenticode-sign the built binary before cache/upload.
+               Windows-only (no-op elsewhere). Requires smctl + signtool on
+               PATH and DigiCert KeyLocker env vars (SM_HOST, SM_API_KEY,
+               SM_CLIENT_CERT_FILE, SM_CLIENT_CERT_PASSWORD, SHA1, KEY_ALIAS).
   --clean:     (opt) whether to clean up after the build
   --container: (opt) build using builder container rather than local dev tools
   --arch:      (opt) build on a specific architecture
@@ -176,7 +180,7 @@ if (args.build) {
         lastBuilder = builder;
         p = p.then(() => {
           log(`building for version=${version}, size=${size} arch=${arch}`);
-          return builder.buildFromSource(args.upload, args.cache, args.container, arch, args.ptrCompression);
+          return builder.buildFromSource(args.upload, args.cache, args.container, arch, args.ptrCompression, args.sign);
         });
       });
     });

--- a/js2bin.js
+++ b/js2bin.js
@@ -28,11 +28,8 @@ command-args: take the form of --name=value
               e.g. --build-version=v2
   --download-url: (opt) Custom URL to download pre-built binaries from
                 e.g. --download-url=https://example.com/binaries/
-  --verify-signature: (opt) After downloading the cached binary and before
-                modifying it, run signtool verify /pa on it. Fails the build
-                if the cached binary is unsigned or has an invalid signature.
-                Windows-only (no-op on other platforms). Requires signtool.exe
-                on PATH (Windows SDK).
+  --verify-signature: (opt) Run signtool verify /pa on the downloaded
+                binary before modifying it. Windows-only (no-op elsewhere).
   --enable-overlay: (opt) Use an overlay-enabled cached binary (built via --ci --enable-overlay).
                     Disabled by default.
   --signing-public-key: Path to ECDSA P-256 public key PEM file to embed into

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -435,18 +435,12 @@ class NodeJsBuilder {
     return runCommand('signtool', ['verify', '/pa', cachedFile]);
   }
 
-  // Windows-only. Authenticode-sign the built node binary in place using
-  // DigiCert KeyLocker (smctl + signtool). Expects SM_HOST, SM_API_KEY,
-  // SM_CLIENT_CERT_FILE, SM_CLIENT_CERT_PASSWORD, SHA1, KEY_ALIAS env vars
-  // from the caller. No-op on non-Windows.
+  // Windows-only. Authenticode-sign using DigiCert KeyLocker (smctl +
+  // signtool). Expects SHA1, KEY_ALIAS, and SM_* env vars from the caller.
+  // Chained in one shell; splitting breaks with NTE_PERM 0x8009002d.
+  // shell: true so cmd.exe preserves the quoted /d argument.
   signWindowsBinary(filePath) {
     if (!isWindows) return Promise.resolve();
-    // Chained in one cmd.exe shell so smctl's KSP session state survives
-    // across signtool. Splitting breaks with NTE_PERM 0x8009002d.
-    // { shell: true } so cmd.exe parses the quoted /d argument as one
-    // token (otherwise argv serialization strips the quotes).
-    // Inheriting cwd from the parent process matches cribl bleat-msi's
-    // working pattern (relative cwd, no explicit override).
     const cmd =
       'smctl windows ksp register && ' +
       'smctl windows certsync --keypair-alias=%key_alias% && ' +

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -430,7 +430,9 @@ class NodeJsBuilder {
 
   // Windows-only. Requires signtool.exe on PATH (Windows SDK).
   verifyWindowsSignature(cachedFile) {
-    if (!isWindows) return Promise.resolve();
+    if (!isWindows) {
+      throw new Error('--verify-signature is Windows-only (requires signtool.exe)');
+    }
     log(`verifying Authenticode signature: ${cachedFile}`);
     return runCommand('signtool', ['verify', '/pa', cachedFile]);
   }
@@ -440,7 +442,9 @@ class NodeJsBuilder {
   // Chained in one shell; splitting breaks with NTE_PERM 0x8009002d.
   // shell: true so cmd.exe preserves the quoted /d argument.
   signWindowsBinary(filePath) {
-    if (!isWindows) return Promise.resolve();
+    if (!isWindows) {
+      throw new Error('--sign is Windows-only (requires signtool.exe and DigiCert KeyLocker)');
+    }
     const cmd =
       'smctl windows ksp register && ' +
       'smctl windows certsync --keypair-alias=%key_alias% && ' +

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -447,7 +447,7 @@ class NodeJsBuilder {
     const cmd =
       'smctl windows ksp register && ' +
       'smctl windows certsync --keypair-alias=%key_alias% && ' +
-      `signtool sign /d "Cribl Node (js2bin)" /tr http://timestamp.digicert.com ` +
+      `signtool sign /d "Cribl Node" /tr http://timestamp.digicert.com ` +
         `/td SHA256 /fd SHA256 /sha1 "%sha1%" "${filePath}" && ` +
       'smctl windows certdesync';
     return runCommand('cmd', ['/c', cmd]);

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -443,25 +443,20 @@ class NodeJsBuilder {
     if (!isWindows) return Promise.resolve();
     // Chained in one cmd.exe shell so smctl's KSP session state survives
     // across signtool. Splitting breaks with NTE_PERM 0x8009002d.
-    // Must use { shell: true } so cmd.exe parses the quoted /d argument
-    // as one token (otherwise argv serialization strips the quotes and
-    // signtool sees multiple tokens).
-    // KeyLocker's KSP is cwd-sensitive; running signtool from anywhere
-    // other than where the .p12 was decoded also triggers NTE_PERM
-    // 0x8009002d. Pin cwd to dirname(SM_CLIENT_CERT_FILE).
+    // { shell: true } so cmd.exe parses the quoted /d argument as one
+    // token (otherwise argv serialization strips the quotes).
+    // Inheriting cwd from the parent process matches cribl bleat-msi's
+    // working pattern (relative cwd, no explicit override).
     const cmd =
       'smctl windows ksp register && ' +
       'smctl windows certsync --keypair-alias=%key_alias% && ' +
       `signtool sign /d "Cribl Node" /tr http://timestamp.digicert.com ` +
         `/td SHA256 /fd SHA256 /sha1 "%sha1%" "${filePath}" && ` +
       'smctl windows certdesync';
-    const certFile = process.env.SM_CLIENT_CERT_FILE;
-    const cwd = certFile ? dirname(certFile) : undefined;
     log(`signing Authenticode signature: ${filePath}`);
-    if (cwd) log(`signtool cwd: ${cwd}`);
     log(`running: ${cmd} ...`);
     return new Promise((resolve, reject) => {
-      spawn(cmd, { shell: true, stdio: 'inherit', cwd })
+      spawn(cmd, { shell: true, stdio: 'inherit' })
         .once('error', reject)
         .once('close', (code) => {
           if (code !== 0) {

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -446,16 +446,22 @@ class NodeJsBuilder {
     // Must use { shell: true } so cmd.exe parses the quoted /d argument
     // as one token (otherwise argv serialization strips the quotes and
     // signtool sees multiple tokens).
+    // KeyLocker's KSP is cwd-sensitive; running signtool from anywhere
+    // other than where the .p12 was decoded also triggers NTE_PERM
+    // 0x8009002d. Pin cwd to dirname(SM_CLIENT_CERT_FILE).
     const cmd =
       'smctl windows ksp register && ' +
       'smctl windows certsync --keypair-alias=%key_alias% && ' +
       `signtool sign /d "Cribl Node" /tr http://timestamp.digicert.com ` +
         `/td SHA256 /fd SHA256 /sha1 "%sha1%" "${filePath}" && ` +
       'smctl windows certdesync';
+    const certFile = process.env.SM_CLIENT_CERT_FILE;
+    const cwd = certFile ? dirname(certFile) : undefined;
     log(`signing Authenticode signature: ${filePath}`);
+    if (cwd) log(`signtool cwd: ${cwd}`);
     log(`running: ${cmd} ...`);
     return new Promise((resolve, reject) => {
-      spawn(cmd, { shell: true, stdio: 'inherit' })
+      spawn(cmd, { shell: true, stdio: 'inherit', cwd })
         .once('error', reject)
         .once('close', (code) => {
           if (code !== 0) {

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -427,7 +427,21 @@ class NodeJsBuilder {
       .catch(err => this.printDiskUsage().then(() => { throw err; }));
   }
 
-  buildFromCached(platform = 'linux', arch = 'x64', outFile = undefined, cache = false, size, customDownloadUrl) {
+  /*
+   * Run `signtool verify /pa` on a cached Windows binary. Windows-only;
+   * on non-Windows this is a no-op. Requires signtool.exe on PATH (ships
+   * with the Windows SDK). Used between the download and modify phases of
+   * buildFromCached when --verify-signature is set, so a tampered GitHub
+   * release asset is rejected before its bytes run through the modify
+   * logic.
+   */
+  verifyWindowsSignature(cachedFile) {
+    if (!isWindows) return Promise.resolve();
+    log(`verifying Authenticode signature: ${cachedFile}`);
+    return runCommand('signtool', ['verify', '/pa', cachedFile]);
+  }
+
+  buildFromCached(platform = 'linux', arch = 'x64', outFile = undefined, cache = false, size, customDownloadUrl, verifySignature = false) {
     // Validate the signing key before any I/O so bad inputs fail fast without
     // a cache download.
     let keyPem = null;
@@ -445,8 +459,14 @@ class NodeJsBuilder {
 
     if (size) this.placeHolderSizeMB = parseInt( size.toUpperCase().replaceAll('MB', '') )
 
+    let cachedFilePath;
     return this.downloadCachedBuild(platform, arch, customDownloadUrl)
       .then(cachedFile => {
+        cachedFilePath = cachedFile;
+        return verifySignature ? this.verifyWindowsSignature(cachedFile) : Promise.resolve();
+      })
+      .then(() => {
+        const cachedFile = cachedFilePath;
         const placeholder = this.getPlaceholderContent(this.placeHolderSizeMB);
 
         outFile = resolve(outFile || `app-${platform}-${arch}-${this.version}`);

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -380,7 +380,7 @@ class NodeJsBuilder {
   // 3. install _third_party_main.js
   // 4. process mainAppFile (gzip, base64 encode it) - could be a placeholder file
   // 5. kick off ./configure & build
-  buildFromSource(uploadBuild, cache, container, arch, ptrCompression) {
+  buildFromSource(uploadBuild, cache, container, arch, ptrCompression, sign = false) {
     const makeArgs = isWindows ? ['x64', 'no-cctest'] : [`-j${os.cpus().length}`];
     const configArgs = [];
     if(ptrCompression) {
@@ -417,6 +417,7 @@ class NodeJsBuilder {
         }
         return this.buildInContainer(ptrCompression);
       })
+      .then(() => sign ? this.signWindowsBinary(this.resultFile) : Promise.resolve())
       .then(() => this.uploadNodeBinary(undefined, uploadBuild, cache, arch, ptrCompression))
       .then(() => this.printDiskUsage())
       // .then(() => this.cleanupBuild().catch(err => log(err)))
@@ -432,6 +433,24 @@ class NodeJsBuilder {
     if (!isWindows) return Promise.resolve();
     log(`verifying Authenticode signature: ${cachedFile}`);
     return runCommand('signtool', ['verify', '/pa', cachedFile]);
+  }
+
+  // Windows-only. Authenticode-sign the built node binary in place using
+  // DigiCert KeyLocker (smctl + signtool). Expects SM_HOST, SM_API_KEY,
+  // SM_CLIENT_CERT_FILE, SM_CLIENT_CERT_PASSWORD, SHA1, KEY_ALIAS env vars
+  // from the caller. No-op on non-Windows.
+  signWindowsBinary(filePath) {
+    if (!isWindows) return Promise.resolve();
+    log(`signing Authenticode signature: ${filePath}`);
+    // Chained in one cmd.exe shell so smctl's KSP session state survives
+    // across signtool. Splitting breaks with NTE_PERM 0x8009002d.
+    const cmd =
+      'smctl windows ksp register && ' +
+      'smctl windows certsync --keypair-alias=%key_alias% && ' +
+      `signtool sign /d "Cribl Node (js2bin)" /tr http://timestamp.digicert.com ` +
+        `/td SHA256 /fd SHA256 /sha1 "%sha1%" "${filePath}" && ` +
+      'smctl windows certdesync';
+    return runCommand('cmd', ['/c', cmd]);
   }
 
   buildFromCached(platform = 'linux', arch = 'x64', outFile = undefined, cache = false, size, customDownloadUrl, verifySignature = false) {

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -427,14 +427,7 @@ class NodeJsBuilder {
       .catch(err => this.printDiskUsage().then(() => { throw err; }));
   }
 
-  /*
-   * Run `signtool verify /pa` on a cached Windows binary. Windows-only;
-   * on non-Windows this is a no-op. Requires signtool.exe on PATH (ships
-   * with the Windows SDK). Used between the download and modify phases of
-   * buildFromCached when --verify-signature is set, so a tampered GitHub
-   * release asset is rejected before its bytes run through the modify
-   * logic.
-   */
+  // Windows-only. Requires signtool.exe on PATH (Windows SDK).
   verifyWindowsSignature(cachedFile) {
     if (!isWindows) return Promise.resolve();
     log(`verifying Authenticode signature: ${cachedFile}`);

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -3,7 +3,7 @@ const { log, download, upload, deleteArtifact, getAssetIdByName, fetch, mkdirp, 
 const { brotliCompressSync, createGunzip } = require('zlib');
 const zlib = require('zlib');
 const { join, dirname, basename, parse, resolve } = require('path');
-const { execFile } = require('child_process');
+const { execFile, spawn } = require('child_process');
 const { promisify } = require('util');
 const fs = require('fs');
 const os = require('os');
@@ -441,16 +441,30 @@ class NodeJsBuilder {
   // from the caller. No-op on non-Windows.
   signWindowsBinary(filePath) {
     if (!isWindows) return Promise.resolve();
-    log(`signing Authenticode signature: ${filePath}`);
     // Chained in one cmd.exe shell so smctl's KSP session state survives
     // across signtool. Splitting breaks with NTE_PERM 0x8009002d.
+    // Must use { shell: true } so cmd.exe parses the quoted /d argument
+    // as one token (otherwise argv serialization strips the quotes and
+    // signtool sees multiple tokens).
     const cmd =
       'smctl windows ksp register && ' +
       'smctl windows certsync --keypair-alias=%key_alias% && ' +
       `signtool sign /d "Cribl Node" /tr http://timestamp.digicert.com ` +
         `/td SHA256 /fd SHA256 /sha1 "%sha1%" "${filePath}" && ` +
       'smctl windows certdesync';
-    return runCommand('cmd', ['/c', cmd]);
+    log(`signing Authenticode signature: ${filePath}`);
+    log(`running: ${cmd} ...`);
+    return new Promise((resolve, reject) => {
+      spawn(cmd, { shell: true, stdio: 'inherit' })
+        .once('error', reject)
+        .once('close', (code) => {
+          if (code !== 0) {
+            reject(new Error(`signtool exited with code: ${code}`));
+          } else {
+            resolve();
+          }
+        });
+    });
   }
 
   buildFromCached(platform = 'linux', arch = 'x64', outFile = undefined, cache = false, size, customDownloadUrl, verifySignature = false) {


### PR DESCRIPTION
## Summary

Adds two opt-in, Windows-only flags to js2bin:

- **`--verify-signature`** (for `--build`): runs `signtool verify /pa` on the downloaded cached node binary between download and modify. Fails the build if the binary is unsigned or has an invalid Authenticode signature.
- **`--sign`** (for `--ci`): Authenticode-signs the built node binary using DigiCert KeyLocker (smctl + signtool) between the build and the upload/cache steps. Enables downstream consumers to verify the upstream binary's origin before using it.

Both flags are no-ops on non-Windows platforms. Both require `signtool.exe` on PATH (ships with the Windows SDK). `--sign` additionally requires `smctl` and DigiCert KeyLocker environment variables (SM_HOST, SM_API_KEY, SM_CLIENT_CERT_FILE, SM_CLIENT_CERT_PASSWORD, SHA1, KEY_ALIAS).

## Motivation

The Cribl Edge build wraps a prebuilt `node.exe` that js2bin downloads from this repo's GitHub releases. For chain-of-custody compliance (INFRA-7979, Build Process Security doc), we need two seams:

1. **Producer side (`--sign`):** the js2bin `--ci` Jenkins job must sign the built node binary before it gets uploaded to GitHub releases. Without this, there is no way to assert the binary was produced by Cribl's CI pipeline.
2. **Consumer side (`--verify-signature`):** cribl's `buildit.sh` must verify that signature before js2bin's modify logic runs on the downloaded bytes. Without this, the modify step trusts arbitrary bytes from GitHub.

Together, the two flags close the chain: signed at production, verified at consumption.

## Changes

- `src/NodeBuilder.js`:
  - `verifyWindowsSignature(cachedFile)`: runs `signtool verify /pa`.
  - `signWindowsBinary(filePath)`: runs the smctl + signtool cycle chained in a single `cmd.exe` shell (splitting breaks with NTE_PERM 0x8009002d because smctl's KSP session state does not survive across processes).
  - `buildFromCached` takes a `verifySignature` boolean; runs verify between download and modify.
  - `buildFromSource` takes a `sign` boolean; runs sign between build and upload (so both the cached copy and the uploaded asset carry the signature).
- `js2bin.js`: `--verify-signature` and `--sign` flags, help text, threaded through.

## Test plan

### `--verify-signature` (consumer side)

* [ ] Run `js2bin --build --verify-signature` on Windows against a signed release asset -> verify passes, build proceeds, output is correct. **BLOCKED by this PR — can only run after `--sign` produces a signed asset post-merge. Verifiable immediately after first post-merge js2bin Jenkins run publishes a signed asset.**
* [x] Run against an unsigned asset -> verify fails, build aborts before modify.
* [x] Run without the flag on Windows -> behavior unchanged.
* [x] Run with the flag on Linux/darwin -> flag silently ignored, behavior unchanged.

### `--sign` (producer side)

* [x] Run `js2bin --ci --sign` on Windows via the js2bin Jenkins pipeline (wrapped in `auth.withWinSigning`) -> `signtool verify /pa` on the uploaded GitHub release asset returns `Successfully verified`. Ran this pointing at my own fork & branch.
* [x] Run with `--sign` on Linux/darwin -> flag silently ignored, behavior unchanged. (Quick local test.)

## Test Results (Consumer)

### Jenkins & Windows, `--verify-signature` against a signed asset

**BLOCKED** by this PR — verifiable post-release once the js2bin Jenkins pipeline runs with `--sign` and publishes a signed release asset.

### Jenkins & Windows, `--verify-signature` against an unsigned asset

The asset `windows-ptrc-x64-22.22.2-v1-6MB` on the `criblio/js2bin` `v1.0.9` release was built and uploaded by the existing `js2bin` Windows Jenkins pipeline before anyone added a signing step to it.

```sh
11:01:50  + JS2BIN_VERIFY_FLAG=--verify-signature
11:01:50  + ./node_modules/.bin/js2bin --build --cache --verify-signature --node=22.22.2 --platform=windows-ptrc --app=/c/home/jenkins/agent/workspace/dist/sluice-prod/bin/cribl.bundle.js --name=cribl --arch=x64 --build-version=v1
11:01:50  2026-05-11T16:01:40.441Z - building for version=22.22.2, plat=windows-ptrc app=C:/home/jenkins/agent/workspace/dist/sluice-prod/bin/cribl.bundle.js} arch=x64
11:02:17  2026-05-11T16:02:13.659Z - main app file content size = 4889641, place holder size MB = 6
11:02:17  2026-05-11T16:02:13.659Z - downloading https://github.com/criblio/js2bin/releases/download/v1.0.9/windows-ptrc-x64-22.22.2-v1-6MB to C:\home\jenkins\agent\workspace\cache\windows-ptrc-x64-22.22.2-v1-6MB ...
11:02:17  2026-05-11T16:02:14.070Z - following redirect ...
11:02:17  2026-05-11T16:02:14.070Z - downloading https://release-assets.githubusercontent.com/github-production-release-asset/193164769/497116f4-4c7a-4ed5-9c56-bb27d78976e8?[...redacted...] to C:\home\jenkins\agent\workspace\cache\windows-ptrc-x64-22.22.2-v1-6MB ...
11:02:18  2026-05-11T16:02:17.879Z - verifying Authenticode signature: C:\home\jenkins\agent\workspace\cache\windows-ptrc-x64-22.22.2-v1-6MB
11:02:18  2026-05-11T16:02:17.879Z - running: signtool verify /pa C:\home\jenkins\agent\workspace\cache\windows-ptrc-x64-22.22.2-v1-6MB ...
11:02:18  File: C:\home\jenkins\agent\workspace\cache\windows-ptrc-x64-22.22.2-v1-6MB
11:02:18  Index  Algorithm  Timestamp
11:02:18  ========================================
11:02:18
11:02:18  Number of errors: 1
11:02:18
11:02:18  SignTool Error: No signature found.
11:02:18  2026-05-11T16:02:17.919Z - Error: signtool verify /pa C:\home\jenkins\agent\workspace\cache\windows-ptrc-x64-22.22.2-v1-6MB exited with code: 1
11:02:18      at ChildProcess.<anonymous> (C:\home\jenkins\agent\workspace\node_modules\js2bin\src\util.js:76:18)
11:02:18      at Object.onceWrapper (node:events:634:26)
11:02:18      at ChildProcess.emit (node:events:519:28)
11:02:18      at maybeClose (node:internal/child_process:1101:16)
11:02:18      at ChildProcess._handle.onexit (node:internal/child_process:304:5)
script returned exit code 1
```

### No flag on non-Windows

Existing behavior preserved.

> Local darwin run: no verify line, 117MB output produced

### `--verify-signature` on non-Windows

No-op - guard short-circuits before signtool is invoked.

> Local darwin run with flag: no verify line, no signtool call, output produced

## Test Results (Producer)

### Run with --sign on Linux/darwin -> flag silently ignored, behavior unchanged
- 1a (`--help`): flag parses cleanly, help text renders, no crash.
- 1b (`--ci` `--sign` `--node=22.14.0`): js2bin ran the full node.js build (got to the OpenSSL compile stage before we killed it at 8s). No signing attempt in the log. The isWindows guard short-circuits signWindowsBinary before it tries to invoke smctl/signtool. Behavior identical to a run without the flag.

### Signing

I ran the existing Jenkins job that publishes `js2bin` artifacts pointed against this branch and my forked repository. 