### PR TITLE
feat(download): verify sha256 against GitHub Releases asset digest

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -153,7 +153,40 @@ function fetch(url, headers) {
   });
 }
 
-function download(url, toFile, headers) {
+// Default GitHub hosts used to locate the Releases API record for a download
+// URL. Mutable via `__setGithubHostsForTest` so tests can redirect the lookup
+// at a local HTTP server without going to github.com.
+let githubReleaseHost = 'github.com';
+let githubApiBase = 'https://api.github.com';
+
+function __setGithubHostsForTest({ releaseHost, apiBase } = {}) {
+  if (releaseHost !== undefined) githubReleaseHost = releaseHost;
+  if (apiBase !== undefined) githubApiBase = apiBase;
+}
+
+function getExpectedSha256(url, headers) {
+  let parsed;
+  try { parsed = new URL(url); } catch { return Promise.resolve(null); }
+  if (parsed.host !== githubReleaseHost) return Promise.resolve(null);
+  // Expected path: /<owner>/<repo>/releases/download/<tag>/<asset...>
+  const parts = parsed.pathname.split('/').filter(Boolean);
+  if (parts.length < 6 || parts[2] !== 'releases' || parts[3] !== 'download') {
+    return Promise.resolve(null);
+  }
+  const [owner, repo, , , tag, ...assetParts] = parts;
+  const assetName = decodeURIComponent(assetParts.join('/'));
+  const apiUrl = `${githubApiBase}/repos/${owner}/${repo}/releases/tags/${tag}`;
+  return fetch(apiUrl, headers).then(body => {
+    const release = JSON.parse(body);
+    if (!release || !Array.isArray(release.assets)) return null;
+    const asset = release.assets.find(a => a.name === assetName);
+    if (!asset || typeof asset.digest !== 'string') return null;
+    const dm = /^sha256:([0-9a-f]{64})$/i.exec(asset.digest);
+    return dm ? dm[1].toLowerCase() : null;
+  });
+}
+
+function streamDownload(url, toFile, headers) {
   return new Promise((resolve, reject) => {
     if (!url || url.length === 0) {
       throw new Error(`Invalid Argument - url [${url}] is undefined or empty!`);
@@ -183,20 +216,50 @@ function download(url, toFile, headers) {
           redirUrl.protocol = origUrl.protocol;
         }
         log('following redirect ...');
-        return download(redirUrl.toString(), toFile, headers).then(resolve, reject);
+        return streamDownload(redirUrl.toString(), toFile, headers).then(resolve, reject);
       }
       if (res.statusCode >= 400) {
         return reject(new Error(`Non-OK response, statusCode=${res.statusCode}, url=${url}`));
       }
       res.on('error', reject);
       mkdirp(dirname(toFile)).then(() => {
+        const hash = crypto.createHash('sha256');
+        res.on('data', chunk => hash.update(chunk));
         const outFile = fs.createWriteStream(toFile);
-        outFile.on('finish', () => resolve(toFile));
+        outFile.on('error', reject);
+        outFile.on('finish', () => resolve({ file: toFile, sha256: hash.digest('hex') }));
         res.pipe(outFile);
       });
     });
+    req.on('error', reject);
     req.end();
-  })
+  });
+}
+
+function download(url, toFile, headers) {
+  return streamDownload(url, toFile, headers)
+    .then(({ file, sha256 }) =>
+      getExpectedSha256(url, headers)
+        .catch(err => {
+          log(`WARN: failed to look up checksum for ${url}: ${err.message}; skipping integrity verification`);
+          return null;
+        })
+        .then(expected => {
+          if (!expected) {
+            log(`WARN: no published checksum available for ${url}; skipping integrity verification`);
+            return file;
+          }
+          if (sha256 !== expected) {
+            const mismatch = new Error(
+              `Checksum mismatch for ${url}: expected sha256:${expected}, got sha256:${sha256}`
+            );
+            mismatch.code = 'ERR_CHECKSUM_MISMATCH';
+            throw mismatch;
+          }
+          log(`verified sha256:${sha256} for ${file}`);
+          return file;
+        })
+    )
     .catch(err => {
       try { fs.unlinkSync(toFile); } catch (ignore) {
       // fail through
@@ -380,4 +443,6 @@ module.exports = {
   renameAsync,
   patchFile,
   assertSupportedKey,
+  getExpectedSha256,
+  __setGithubHostsForTest,
 };

--- a/test/download.test.js
+++ b/test/download.test.js
@@ -1,0 +1,266 @@
+const { describe, it, before, after, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('http');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { download, getExpectedSha256, __setGithubHostsForTest } = require('../src/util');
+
+function sha256Hex(buf) {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+function startServer(handler) {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function tmpFile(name = 'js2bin-dl-test') {
+  return path.join(os.tmpdir(), `${name}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+}
+
+describe('getExpectedSha256', () => {
+  let apiServer;
+  let apiBase;
+  let lastApiPath;
+  let apiResponse;
+
+  before(async () => {
+    apiServer = await startServer((req, res) => {
+      lastApiPath = req.url;
+      if (apiResponse instanceof Error) {
+        res.statusCode = 500;
+        res.end('boom');
+        return;
+      }
+      res.setHeader('content-type', 'application/json');
+      res.end(typeof apiResponse === 'string' ? apiResponse : JSON.stringify(apiResponse));
+    });
+    apiBase = `http://127.0.0.1:${apiServer.address().port}`;
+    __setGithubHostsForTest({ releaseHost: 'github.com', apiBase });
+  });
+
+  after(async () => {
+    __setGithubHostsForTest({ releaseHost: 'github.com', apiBase: 'https://api.github.com' });
+    await stopServer(apiServer);
+  });
+
+  afterEach(() => {
+    apiResponse = undefined;
+    lastApiPath = undefined;
+  });
+
+  it('returns null and skips the API call for non-GitHub URLs', async () => {
+    apiResponse = new Error('should not be called');
+    const result = await getExpectedSha256('https://nodejs.org/dist/v20.18.0/node-v20.18.0.tar.gz');
+    assert.equal(result, null);
+    assert.equal(lastApiPath, undefined);
+  });
+
+  it('returns lowercased hex when the matching asset publishes a sha256 digest', async () => {
+    apiResponse = { assets: [
+      { name: 'darwin-x64-22.22.0-v1-4MB', digest: 'sha256:6AB6DB56627A265924468491817B0D0220DE27181F3F16EAEB2D76A6101102F9' },
+      { name: 'darwin-arm64-22.22.0-v1-4MB', digest: 'sha256:0000000000000000000000000000000000000000000000000000000000000000' }
+    ] };
+    const result = await getExpectedSha256(
+      'https://github.com/criblio/js2bin/releases/download/v1.0.9/darwin-x64-22.22.0-v1-4MB'
+    );
+    assert.equal(result, '6ab6db56627a265924468491817b0d0220de27181f3f16eaeb2d76a6101102f9');
+    assert.equal(lastApiPath, '/repos/criblio/js2bin/releases/tags/v1.0.9');
+  });
+
+  it('returns null when the matching asset has no digest field (older asset)', async () => {
+    apiResponse = { assets: [{ name: 'old-asset', /* no digest */ }] };
+    const result = await getExpectedSha256(
+      'https://github.com/criblio/js2bin/releases/download/v1.0.9/old-asset'
+    );
+    assert.equal(result, null);
+  });
+
+  it('returns null when the digest is not sha256 (e.g. sha512)', async () => {
+    apiResponse = { assets: [{ name: 'asset', digest: 'sha512:' + 'a'.repeat(128) }] };
+    const result = await getExpectedSha256(
+      'https://github.com/criblio/js2bin/releases/download/v1.0.9/asset'
+    );
+    assert.equal(result, null);
+  });
+
+  it('returns null when the asset is not in the release', async () => {
+    apiResponse = { assets: [{ name: 'something-else', digest: 'sha256:' + 'a'.repeat(64) }] };
+    const result = await getExpectedSha256(
+      'https://github.com/criblio/js2bin/releases/download/v1.0.9/missing-asset'
+    );
+    assert.equal(result, null);
+  });
+
+  it('URL-decodes the asset name before matching', async () => {
+    const digest = 'b'.repeat(64);
+    apiResponse = { assets: [{ name: 'name with spaces+plus', digest: `sha256:${digest}` }] };
+    const result = await getExpectedSha256(
+      'https://github.com/criblio/js2bin/releases/download/v1.0.9/name%20with%20spaces%2Bplus'
+    );
+    assert.equal(result, digest);
+  });
+
+  it('rejects when the API returns malformed JSON', async () => {
+    apiResponse = 'not json {';
+    await assert.rejects(
+      getExpectedSha256('https://github.com/criblio/js2bin/releases/download/v1.0.9/asset'),
+      /JSON/i
+    );
+  });
+});
+
+describe('download', () => {
+  // Two servers: one serves the binary, the other serves the GitHub Releases
+  // API response. Both bind on 127.0.0.1:0; tests rewrite `download`'s notion
+  // of GitHub hosts via __setGithubHostsForTest so URL pattern detection
+  // matches the binary server's host.
+  let dlServer, apiServer;
+  let dlHost, apiBase;
+  let dlHandler, apiHandler;
+
+  before(async () => {
+    dlServer = await startServer((req, res) => dlHandler(req, res));
+    apiServer = await startServer((req, res) => apiHandler(req, res));
+    dlHost = `127.0.0.1:${dlServer.address().port}`;
+    apiBase = `http://127.0.0.1:${apiServer.address().port}`;
+    __setGithubHostsForTest({ releaseHost: dlHost, apiBase });
+  });
+
+  after(async () => {
+    __setGithubHostsForTest({ releaseHost: 'github.com', apiBase: 'https://api.github.com' });
+    await stopServer(dlServer);
+    await stopServer(apiServer);
+  });
+
+  function downloadUrl(asset) {
+    return `http://${dlHost}/criblio/js2bin/releases/download/v1.0.9/${asset}`;
+  }
+
+  function serveBytes(bytes) {
+    dlHandler = (req, res) => {
+      res.setHeader('content-type', 'application/octet-stream');
+      res.end(bytes);
+    };
+  }
+
+  function serveApi(payload) {
+    apiHandler = (req, res) => {
+      if (payload === 'boom') { res.statusCode = 500; res.end('boom'); return; }
+      res.setHeader('content-type', 'application/json');
+      res.end(typeof payload === 'string' ? payload : JSON.stringify(payload));
+    };
+  }
+
+  it('resolves and writes the file when the sha256 matches the published digest', async () => {
+    const bytes = Buffer.from('hello world');
+    serveBytes(bytes);
+    serveApi({ assets: [{ name: 'asset-ok', digest: `sha256:${sha256Hex(bytes)}` }] });
+
+    const dest = tmpFile();
+    try {
+      const result = await download(downloadUrl('asset-ok'), dest);
+      assert.equal(result, dest);
+      assert.deepEqual(fs.readFileSync(dest), bytes);
+    } finally {
+      try { fs.unlinkSync(dest); } catch {}
+    }
+  });
+
+  it('rejects with ERR_CHECKSUM_MISMATCH and removes the partial file on mismatch', async () => {
+    const bytes = Buffer.from('actual bytes that hash to something');
+    serveBytes(bytes);
+    serveApi({ assets: [{ name: 'asset-bad', digest: 'sha256:' + 'a'.repeat(64) }] });
+
+    const dest = tmpFile();
+    await assert.rejects(
+      download(downloadUrl('asset-bad'), dest),
+      err => err.code === 'ERR_CHECKSUM_MISMATCH'
+    );
+    assert.equal(fs.existsSync(dest), false, 'partial file should be removed');
+  });
+
+  it('resolves with a warning when the published asset has no digest', async () => {
+    const bytes = Buffer.from('payload without digest');
+    serveBytes(bytes);
+    serveApi({ assets: [{ name: 'asset-no-digest' }] });
+
+    const dest = tmpFile();
+    try {
+      const result = await download(downloadUrl('asset-no-digest'), dest);
+      assert.equal(result, dest);
+      assert.deepEqual(fs.readFileSync(dest), bytes);
+    } finally {
+      try { fs.unlinkSync(dest); } catch {}
+    }
+  });
+
+  it('resolves with a warning when the API endpoint returns 500', async () => {
+    const bytes = Buffer.from('payload despite api down');
+    serveBytes(bytes);
+    serveApi('boom');
+
+    const dest = tmpFile();
+    try {
+      const result = await download(downloadUrl('asset-api-500'), dest);
+      assert.equal(result, dest);
+      assert.deepEqual(fs.readFileSync(dest), bytes);
+    } finally {
+      try { fs.unlinkSync(dest); } catch {}
+    }
+  });
+
+  it('follows redirects and verifies the final bytes against the published digest', async () => {
+    const finalBytes = Buffer.from('bytes served after redirect');
+    let hitCount = 0;
+    dlHandler = (req, res) => {
+      hitCount += 1;
+      if (req.url.includes('/redirect-target')) {
+        res.setHeader('content-type', 'application/octet-stream');
+        res.end(finalBytes);
+        return;
+      }
+      res.statusCode = 302;
+      res.setHeader('location', `http://${dlHost}/redirect-target`);
+      res.end();
+    };
+    serveApi({ assets: [{ name: 'asset-redirect', digest: `sha256:${sha256Hex(finalBytes)}` }] });
+
+    const dest = tmpFile();
+    try {
+      const result = await download(downloadUrl('asset-redirect'), dest);
+      assert.equal(result, dest);
+      assert.deepEqual(fs.readFileSync(dest), finalBytes);
+      assert.ok(hitCount >= 2, 'redirect should have been followed');
+    } finally {
+      try { fs.unlinkSync(dest); } catch {}
+    }
+  });
+
+  it('hashes correctly across multiple stream chunks (large body)', async () => {
+    // Larger than the default highWaterMark (16 KB) to ensure the data event
+    // fires repeatedly and the hash is updated per chunk rather than once.
+    const bytes = crypto.randomBytes(5 * 1024 * 1024);
+    serveBytes(bytes);
+    serveApi({ assets: [{ name: 'asset-large', digest: `sha256:${sha256Hex(bytes)}` }] });
+
+    const dest = tmpFile();
+    try {
+      const result = await download(downloadUrl('asset-large'), dest);
+      assert.equal(result, dest);
+      assert.equal(fs.statSync(dest).size, bytes.length);
+      assert.equal(sha256Hex(fs.readFileSync(dest)), sha256Hex(bytes));
+    } finally {
+      try { fs.unlinkSync(dest); } catch {}
+    }
+  });
+});


### PR DESCRIPTION
Stream the response through a sha256 hasher and, for URLs that match the GitHub Releases download pattern, look up the asset's `digest` field on the Releases API. On mismatch, reject with ERR_CHECKSUM_MISMATCH and remove the partial file. Older assets without a published `digest` and non-GitHub URLs (e.g. nodejs.org tarballs) warn and continue, so the change is backward compatible for callers that previously relied on unverified downloads.

Adds tests (test/download.test.js) covering getExpectedSha256 parsing, the happy path, mismatch detection, missing-digest and API-down fallbacks, redirect following, and multi-chunk hashing.