### PR TITLE
added support for encrypted overlay bundle

### DIFF
--- a/js2bin.js
+++ b/js2bin.js
@@ -33,6 +33,10 @@ command-args: take the form of --name=value
   --signing-public-key: Path to ECDSA P-256 public key PEM file to embed into
                 the binary. Required with --enable-overlay.
                 e.g. --signing-public-key=/path/to/overlay-signing.pub
+  --encryption-key: (opt) Path to a file containing a 64-char hex AES-256 key to embed
+                into the binary for decrypting encrypted overlay bundles (bundle.js.enc).
+                Only valid with --build --enable-overlay.
+                e.g. --encryption-key=/path/to/overlay-encryption.key
 
 --overlay: build a signed overlay bundle from a JS application
   --app:      Path to your (bundled) application
@@ -99,6 +103,7 @@ function parseArgs() {
   args.downloadUrl = (args['download-url'] || undefined);
   args.enableOverlay = (args['enable-overlay'] === true);
   args.signingPublicKey = (args['signing-public-key'] || undefined);
+  args.encryptionKey = (args['encryption-key'] || undefined);
   if (args.signingPublicKey && !args.enableOverlay) {
     return usage('--signing-public-key requires --enable-overlay');
   }
@@ -107,6 +112,12 @@ function parseArgs() {
   }
   if (args.build && args.enableOverlay && !args.signingPublicKey) {
     return usage('--build --enable-overlay requires --signing-public-key');
+  }
+  if (args.encryptionKey && !args.enableOverlay) {
+    return usage('--encryption-key requires --enable-overlay');
+  }
+  if (args.encryptionKey && !args.build) {
+    return usage('--encryption-key is only supported with --build (key is embedded at build time)');
   }
   return args;
 }
@@ -130,7 +141,7 @@ if (args.build) {
   const plats = asArray(args.platform);
   versions.forEach(version => {
     plats.forEach(plat => {
-      const builder = new NodeJsBuilder(args.dir, version, app, args.name, undefined, args.buildVersion, undefined, args.signingPublicKey, args.enableOverlay);
+      const builder = new NodeJsBuilder(args.dir, version, app, args.name, undefined, args.buildVersion, undefined, args.signingPublicKey, args.enableOverlay, args.encryptionKey);
       p = p.then(() => {
         const arch = args.arch || 'x64';
         log(`building for version=${version}, plat=${plat} app=${app}} arch=${arch}`);
@@ -169,7 +180,7 @@ if (args.build) {
     let lastBuilder;
     sizes.forEach(size => {
       archs.forEach(arch => {
-        const builder = new NodeJsBuilder(args.dir, version, size, undefined, undefined, args.buildVersion, args.commitHash, undefined, args.enableOverlay);
+        const builder = new NodeJsBuilder(args.dir, version, size, undefined, undefined, args.buildVersion, args.commitHash, undefined, args.enableOverlay, undefined);
         lastBuilder = builder;
         p = p.then(() => {
           log(`building for version=${version}, size=${size} arch=${arch}`);

--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -68,7 +68,7 @@ function parseSemverFromDescribe(desc) {
 }
 
 class NodeJsBuilder {
-  constructor(cwd, version, mainAppFile, appName, patchDir, buildVersion, commitHash, signingPublicKey, enableOverlay) {
+  constructor(cwd, version, mainAppFile, appName, patchDir, buildVersion, commitHash, signingPublicKey, enableOverlay, encryptionKey) {
     this.version = version;
     this.appFile = resolve(mainAppFile);
     this.appName = appName;
@@ -99,6 +99,7 @@ class NodeJsBuilder {
     this.commitHash = commitHash;
     this.signingPublicKey = signingPublicKey || '';
     this.enableOverlay = !!enableOverlay;
+    this.encryptionKey = encryptionKey || '';
   }
 
   static platform() {
@@ -265,6 +266,16 @@ class NodeJsBuilder {
     return Buffer.from('`' + line.repeat(KEY_PLACEHOLDER_SIZE / line.length) + '`');
   }
 
+  // 128 B region reserved for the AES-256-GCM encryption key (64 hex chars).
+  // Written at --ci time and overwritten at --build time when the user passes
+  // --encryption-key. Runtime detects an unmodified slot via the backtick+tilde
+  // sentinel — same scheme as the signing key placeholder.
+  getEncryptionKeyPlaceholderContent() {
+    const ENC_KEY_PLACEHOLDER_SIZE = 128;
+    const line = '~E~n~c~K~e~y~P~\n';
+    return Buffer.from('`' + line.repeat(ENC_KEY_PLACEHOLDER_SIZE / line.length) + '`');
+  }
+
   getAppContentToBundle() {
     const mainAppFileCont = brotliCompressSync(
       fs.readFileSync(this.appFile),
@@ -281,9 +292,10 @@ class NodeJsBuilder {
   prepareNodeJsBuild() {
     // install _third_party_main.js — pick overlay or non-overlay version
     // install app_main.js
-    // install _js2bin_signing_key.js placeholder (when overlay is enabled)
+    // install _js2bin_signing_key.js and _js2bin_encryption_key.js placeholders (when overlay is enabled)
     const appMainPath = this.nodePath('lib', '_js2bin_app_main.js');
     const keyPath = this.nodePath('lib', '_js2bin_signing_key.js');
+    const encKeyPath = this.nodePath('lib', '_js2bin_encryption_key.js');
     return Promise.resolve()
       .then(() => {
         const srcFile = this.enableOverlay ? '_third_party_main_overlay.js' : '_third_party_main.js';
@@ -303,6 +315,7 @@ class NodeJsBuilder {
       .then(() => {
         if (this.enableOverlay) {
           fs.writeFileSync(keyPath, this.getKeyPlaceholderContent());
+          fs.writeFileSync(encKeyPath, this.getEncryptionKeyPlaceholderContent());
         }
       });
   }
@@ -428,12 +441,22 @@ class NodeJsBuilder {
   }
 
   buildFromCached(platform = 'linux', arch = 'x64', outFile = undefined, cache = false, size, customDownloadUrl) {
-    // Validate the signing key before any I/O so bad inputs fail fast without
-    // a cache download.
+    // Validate keys before any I/O so bad inputs fail fast without a cache download.
     let keyPem = null;
     if (this.enableOverlay && this.signingPublicKey) {
       keyPem = fs.readFileSync(this.signingPublicKey);
       assertSupportedKey(keyPem, { type: 'public', source: this.signingPublicKey });
+    }
+
+    let encKeyHex = null;
+    if (this.encryptionKey) {
+      const raw = fs.readFileSync(this.encryptionKey, 'utf8').trim();
+      if (!/^[0-9a-fA-F]{64}$/.test(raw)) {
+        throw new Error(
+          `Encryption key file ${this.encryptionKey} must contain exactly 64 hex characters (32 bytes). Got ${raw.length} characters.`
+        );
+      }
+      encKeyHex = raw;
     }
 
     const mainAppFileCont = this.getAppContentToBundle();
@@ -481,6 +504,20 @@ class NodeJsBuilder {
           execFileCont.fill(0, keyIdx, keyIdx + keyPlaceholder.length);
           keyPem.copy(execFileCont, keyIdx);
           log(`embedded signing public key (${keyPem.length} bytes) at offset ${keyIdx}`);
+        }
+
+        if (encKeyHex) {
+          const encKeyPlaceholder = this.getEncryptionKeyPlaceholderContent();
+          const encKeyIdx = execFileCont.indexOf(encKeyPlaceholder);
+          if (encKeyIdx < 0) {
+            throw new Error(
+              'Could not find encryption-key placeholder in file=' + cachedFile + '. ' +
+              'The cached binary must be built with --ci --enable-overlay.'
+            );
+          }
+          execFileCont.fill(0, encKeyIdx, encKeyIdx + encKeyPlaceholder.length);
+          execFileCont.write(encKeyHex, encKeyIdx);
+          log(`embedded encryption key with ${encKeyHex.length} chars at offset ${encKeyIdx}`);
         }
 
         log(`writing native binary ${outFile}`);

--- a/src/_third_party_main_overlay.js
+++ b/src/_third_party_main_overlay.js
@@ -41,6 +41,35 @@ function extractEmbeddedKey() {
 
 const EMBEDDED_SIGNING_PUBLIC_KEY = extractEmbeddedKey();
 
+function extractEmbeddedEncryptionKey() {
+  let raw;
+  try {
+    raw = process.binding('natives')._js2bin_encryption_key;
+  } catch {
+    return null;
+  }
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  if (raw.startsWith('`~')) return null;
+  const nullIdx = raw.indexOf('\0');
+  const trimmed = (nullIdx > -1 ? raw.substr(0, nullIdx) : raw).trim();
+  if (!/^[0-9a-fA-F]{64}$/.test(trimmed)) {
+    process.stderr.write('[js2bin] overlay: embedded encryption key is not a valid 64-char hex string. Ignoring.\n');
+    return null;
+  }
+  return trimmed;
+}
+
+const EMBEDDED_ENCRYPTION_KEY = extractEmbeddedEncryptionKey();
+
+function decryptBundle(encData, hexKey) {
+  const iv = encData.slice(0, 12);
+  const authTag = encData.slice(encData.length - 16);
+  const ciphertext = encData.slice(12, encData.length - 16);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', Buffer.from(hexKey, 'hex'), iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
 function verifySignature(data, signature, publicKeyPem) {
   try {
     const verify = crypto.createVerify('SHA256');
@@ -55,8 +84,13 @@ function verifySignature(data, signature, publicKeyPem) {
 function tryLoadOverlayBundle(execDir) {
   const overlayDir = process.env.JS2BIN_OVERLAY_DIR || join(execDir, 'overlay', 'current');
 
-  const bundlePath = join(overlayDir, 'bundle.js');
+  const encBundlePath = join(overlayDir, 'bundle.js.enc');
+  const plainBundlePath = join(overlayDir, 'bundle.js');
   const sigPath = join(overlayDir, 'bundle.js.sig');
+
+  // Prefer encrypted bundle over plain bundle. Determine which path to use.
+  const isEncrypted = fs.existsSync(encBundlePath);
+  const bundlePath = isEncrypted ? encBundlePath : plainBundlePath;
 
   // Read the signature first — it's tiny (~70 bytes) — so a missing or empty
   // sig short-circuits before we touch the (potentially much larger) bundle.
@@ -81,6 +115,20 @@ function tryLoadOverlayBundle(execDir) {
     return null;
   }
   if (bundleData.length === 0) return null;
+
+  // Decrypt if the bundle is encrypted.
+  if (isEncrypted) {
+    if (!EMBEDDED_ENCRYPTION_KEY) {
+      process.stderr.write('[js2bin] overlay: bundle.js.enc found but no encryption key embedded — binary was not built with --encryption-key. Falling back to embedded JS.\n');
+      return null;
+    }
+    try {
+      bundleData = decryptBundle(bundleData, EMBEDDED_ENCRYPTION_KEY);
+    } catch (err) {
+      process.stderr.write(`[js2bin] overlay: failed to decrypt bundle.js.enc: ${err.message}. Falling back to embedded JS.\n`);
+      return null;
+    }
+  }
 
   if (!EMBEDDED_SIGNING_PUBLIC_KEY) {
     process.stderr.write('[js2bin] overlay: no embedded signing key — binary was not built with --signing-public-key. Ignoring overlay bundle.\n');

--- a/test/overlay-integration.test.js
+++ b/test/overlay-integration.test.js
@@ -347,6 +347,100 @@ describe('Overlay Integration: Full Binary Flow', async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tier 1: Encrypted Bundle — unit-level tests (no binary required)
+// ---------------------------------------------------------------------------
+
+function generateEncryptionKey() {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+describe('Overlay Integration: Encryption key placeholder', () => {
+  it('getEncryptionKeyPlaceholderContent produces correct sentinel and size', () => {
+    const { NodeJsBuilder } = require('../src/NodeBuilder');
+    const builder = new NodeJsBuilder(undefined, '22.22.0', __filename, undefined, undefined, undefined, undefined, undefined, true);
+    const placeholder = builder.getEncryptionKeyPlaceholderContent();
+    assert.ok(placeholder.includes('~E~n~c~K~e~y~P~'), 'sentinel not found in placeholder');
+    assert.equal(placeholder.length, 130, `expected 130 bytes (backtick + 128B + backtick), got ${placeholder.length}`);
+  });
+});
+
+describe('Overlay Integration: Encryption CLI validation', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'overlay-enc-cli-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should reject --encryption-key without --enable-overlay', async () => {
+    const encKeyFile = path.join(tmpDir, 'enc.key');
+    fs.writeFileSync(encKeyFile, generateEncryptionKey());
+    const appFile = path.join(tmpDir, 'app.js');
+    fs.writeFileSync(appFile, 'console.log("x");');
+    const result = await runCli([
+      '--build',
+      `--node=${DEFAULT_NODE_VERSION}`,
+      `--app=${appFile}`,
+      `--encryption-key=${encKeyFile}`
+    ]);
+    assert.notEqual(result.code, 0);
+    assert.ok(
+      /requires --enable-overlay/.test(result.stdout + result.stderr),
+      `Expected error about --enable-overlay, got: ${result.stdout}${result.stderr}`
+    );
+  });
+
+  it('should reject --encryption-key on --ci', async () => {
+    const encKeyFile = path.join(tmpDir, 'enc.key');
+    fs.writeFileSync(encKeyFile, generateEncryptionKey());
+    const result = await runCli([
+      '--ci',
+      `--node=${DEFAULT_NODE_VERSION}`,
+      '--size=2MB',
+      '--enable-overlay',
+      `--encryption-key=${encKeyFile}`
+    ]);
+    assert.notEqual(result.code, 0);
+    assert.ok(
+      /only supported with --build/.test(result.stdout + result.stderr),
+      `Expected error about --build, got: ${result.stdout}${result.stderr}`
+    );
+  });
+
+  it('should reject an invalid encryption key (wrong length)', async () => {
+    const { NodeJsBuilder } = require('../src/NodeBuilder');
+    const encKeyFile = path.join(tmpDir, 'bad.key');
+    fs.writeFileSync(encKeyFile, 'deadbeef'); // 8 chars, not 64
+    const kp = generateKeypair();
+    const sigKeyFile = path.join(tmpDir, 'signing.pub');
+    fs.writeFileSync(sigKeyFile, kp.publicKey);
+    const builder = new NodeJsBuilder(tmpDir, '22.22.0', __filename, undefined, undefined, undefined, undefined, sigKeyFile, true, encKeyFile);
+    // Provide a synthetic binary buffer with both placeholders so buildFromCached
+    // can run without a real network download.
+    const dummyBin = path.join(tmpDir, 'dummy-bin');
+    const buf = Buffer.concat([
+      builder.getPlaceholderContent(2),
+      builder.getKeyPlaceholderContent(),
+      builder.getEncryptionKeyPlaceholderContent()
+    ]);
+    fs.writeFileSync(dummyBin, buf);
+    builder.downloadCachedBuild = () => Promise.resolve(dummyBin);
+    try {
+      await builder.buildFromCached('linux', 'x64', path.join(tmpDir, 'out'), true);
+      assert.fail('Expected an error for invalid encryption key');
+    } catch (err) {
+      assert.ok(
+        /64 hex/.test(err.message) || /64-char/.test(err.message),
+        `Expected hex-length error, got: ${err.message}`
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // CLI validation: --signing-public-key lives on --build, not --ci
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR added support for an encrypted overlay bundle.

Overlay loader: When an encrypted bundle is present, extract the AES-256 key embedded in the binary, decrypt it, then pass the result through the existing signature verification and decompression path. Falls back to embedded JS if the key is missing, decryption fails, or the bundle is tampered.

Binary builder: At CI build time, reserve a placeholder slot for the encryption key alongside the existing signing key slot. At application build time, stamp the user-supplied key into that slot.

CLI: Add `--encryption-key` flag, only valid when building an overlay-enabled binary.